### PR TITLE
Fixed Requirements

### DIFF
--- a/crackmapexec.py
+++ b/crackmapexec.py
@@ -21,6 +21,7 @@ from impacket.dcerpc.v5.rpcrt import DCERPCException, RPC_C_AUTHN_LEVEL_PKT_PRIV
 from impacket.ese import ESENT_DB
 from impacket.structure import Structure
 from impacket.nt_errors import STATUS_MORE_ENTRIES
+from impacket.nmb import NetBIOSError
 from impacket.smbconnection import *
 from BaseHTTPServer import BaseHTTPRequestHandler
 from argparse import RawTextHelpFormatter
@@ -2310,6 +2311,8 @@ def connect(host):
             smb.logoff()
         except socket.error:
             smb = SMBConnection(host, host, None, args.port)
+	except NetBIOSError:
+            pass
 
         if args.user is not None and (args.passwd is not None or args.hash is not None):
             lmhash = ''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 git+git://github.com/CoreSecurity/impacket
 gevent
 netaddr
+pycrypto
+pyasn1


### PR DESCRIPTION
missing pycrypto and pyasn which don't come by default on many distros or under a virtualenv. Also fixed a netbios Error occuring when trying to do smb.logoff on an unsupported host.
