### PR TITLE
Fix missing args.domain argument

### DIFF
--- a/crackmapexec.py
+++ b/crackmapexec.py
@@ -2384,10 +2384,12 @@ def connect(host):
             if "STATUS_ACCESS_DENIED" in e.message:
                 pass
 
-        domain = smb.getServerDomain()
+        domain = args.domain
         s_name = smb.getServerName()
         if not domain:
-            domain = s_name
+            domain = smb.getServerDomain()
+            if not domain:
+                domain = s_name
 
         print_status("{}:{} is running {} (name:{}) (domain:{})".format(host, args.port, smb.getServerOS(), s_name, domain))
 
@@ -2616,7 +2618,7 @@ if __name__ == '__main__':
     parser.add_argument("-p", metavar="PASSWORD", dest='passwd', default=None, help="Password")
     parser.add_argument("-H", metavar="HASH", dest='hash', default=None, help='NTLM hash')
     parser.add_argument("-n", metavar='NAMESPACE', dest='namespace', default='//./root/cimv2', help='Namespace name (default //./root/cimv2)')
-    parser.add_argument("-d", metavar="DOMAIN", dest='domain', default="WORKGROUP", help="Domain name (default: WORKGROUP)")
+    parser.add_argument("-d", metavar="DOMAIN", dest='domain', default=None, help="Domain name")
     parser.add_argument("-s", metavar="SHARE", dest='share', default="C$", help="Specify a share (default: C$)")
     parser.add_argument("-P", dest='port', type=int, choices={139, 445}, default=445, help="SMB port (default: 445)")
     parser.add_argument("-v", action='store_true', dest='verbose', help="Enable verbose output")


### PR DESCRIPTION
**DOMAIN** (```-d```) argument not actually called/parsed within script. Instead, domain variable set to ```smb.getServerDomain()``` or ```smb.getServerName()``` (pending no results for the former). As a result, local account login attempts fail with a ```STATUS_NO_LOGON_SERVERS``` SMB SessionError when ```smb.getServerDomain()``` succeeds.

To reproduce (example - without ```-d``` flag):
```bash
./crackmapexec.py -t 1 -u Administrator -H aad3b435b51404eeaad3b435b51404ee:daaba380cefc96f5a86107c0be55e9d4 10.7.1.100 --shares
[*] 10.7.1.100:445 is running Windows 6.1 Build 7601 (name:WIN-DEMO-1) (domain:WINTEST)
[-] 10.7.1.100:445 SMB SessionError: STATUS_NO_LOGON_SERVERS(No logon servers are currently available to service the logon request.)
```
With ```-d``` flag (argument not parsed; pre-change):
```bash
./crackmapexec.py -t 1 -d LOCALHOST -u Administrator -H aad3b435b51404eeaad3b435b51404ee:daaba380cefc96f5a86107c0be55e9d4 10.7.1.100 --shares
[*] 10.7.1.100:445 is running Windows 6.1 Build 7601 (name:WIN-DEMO-1) (domain:WINTEST)
[-] 10.7.1.100:445 SMB SessionError: STATUS_NO_LOGON_SERVERS(No logon servers are currently available to service the logon request.)
```
----
Changing the domain variable within the ```connect``` function as proposed in this pull request fixes the issue as shown within the following examples:
Without ```-d``` flag (post-change):
```bash
./crackmapexec.py -t 1 -u Administrator -H aad3b435b51404eeaad3b435b51404ee:daaba380cefc96f5a86107c0be55e9d4 10.7.1.100 --shares
[*] 10.7.1.100:445 is running Windows 6.1 Build 7601 (name:WIN-DEMO-1) (domain:WINTEST)
[-] 10.7.1.100:445 SMB SessionError: STATUS_NO_LOGON_SERVERS(No logon servers are currently available to service the logon request.)
```
With ```-d``` flag (post-change):
```bash
./crackmapexec.py -t 1 -d LOCALHOST -u Administrator -H aad3b435b51404eeaad3b435b51404ee:daaba380cefc96f5a86107c0be55e9d4 10.7.1.100 --shares
[*] 10.7.1.100:445 is running Windows 6.1 Build 7601 (name:WIN-DEMO-1) (domain:LOCALHOST)
[+] 10.7.1.100:445 WIN-DEMO-1 Available shares:
	SHARE			Permissions
	-----			-----------
	ADMIN$			READ, WRITE
	IPC$			NO ACCESS
	C$				READ, WRITE
```

**Note:** Being a bit of a python noob, I apologize in advance if this is an ugly fix but figure it might help highlight the issue in case there is a more elegant solution.

BTW: Thanks for creating/sharing this project, a definite gem!