### PR TITLE
Missing libs

### DIFF
--- a/core/credentials/lsa.py
+++ b/core/credentials/lsa.py
@@ -1,15 +1,17 @@
 from core.credentials.offlineregistry import OfflineRegistry
 from core.credentials.cryptocommon import CryptoCommon
-from core.credentials.commonstructs import LSA_SECRET, LSA_SECRET_BLOB, NL_RECORD
+from core.credentials.commonstructs import LSA_SECRET, LSA_SECRET_BLOB, NL_RECORD, LSA_SECRET_XP
 from impacket import ntlm
 from impacket.winregistry import hexdump
-from Crypto.Cipher import AES
+from Crypto.Cipher import AES, DES, ARC4
 from Crypto.Hash import MD4
 from binascii import hexlify
 import logging
 import ntpath
 import hashlib
 import codecs
+from struct import unpack
+import hmac as HMAC
 
 class LSASecrets(OfflineRegistry):
     def __init__(self, securityFile, bootKey, logger, remoteOps = None, isRemote = False):


### PR DESCRIPTION
During my tests i found out that in case of:
./crackmapexec.py 127.0.0.1 -u user -p pass --lsa 
Tool will (and it did) fail due to missing libraries. This applies to cases when the target is a legacy OS, such as WinXP or Win2k3.

I have fixed the issue by adding missing libraries. Not sure if there are any other missing libs in this file. ;]