### PR TITLE
Fixes issue #144 with coros import issues with gevent

### DIFF
--- a/cme/connection.py
+++ b/cme/connection.py
@@ -4,7 +4,10 @@ from logging import getLogger
 from traceback import format_exc
 from StringIO import StringIO
 from functools import wraps
-from gevent.lock import BoundedSemaphore
+try:
+   from gevent.lock import BoundedSemaphore
+except:
+   from gevent.coros import BoundedSemaphore
 from impacket.smbconnection import SMBConnection, SessionError
 from impacket.nmb import NetBIOSError
 from impacket import tds

--- a/cme/connection.py
+++ b/cme/connection.py
@@ -4,7 +4,7 @@ from logging import getLogger
 from traceback import format_exc
 from StringIO import StringIO
 from functools import wraps
-from gevent.coros import BoundedSemaphore
+from gevent.lock import BoundedSemaphore
 from impacket.smbconnection import SMBConnection, SessionError
 from impacket.nmb import NetBIOSError
 from impacket import tds


### PR DESCRIPTION
The coros module in gevent has been depracted infavor of the lock module, I added a try and except to load the correct module first, but fall back to the old module of coros if needed. 

http://www.gevent.org/whatsnew_1_2.html

Please let me know if you have any questions