### PR TITLE
Replacing characters when they cannot be converted (UTF-8)

### DIFF
--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -423,7 +423,7 @@ class smb(connection):
 
         if hasattr(self, 'server'): self.server.track_host(self.host)
 
-        output = u'{}'.format(exec_method.execute(payload, get_output).strip().decode('utf-8'))
+        output = u'{}'.format(exec_method.execute(payload, get_output).strip().decode('utf-8',errors='replace'))
 
         if self.args.execute or self.args.ps_execute:
             self.logger.success('Executed command {}'.format('via {}'.format(self.args.exec_method) if self.args.exec_method else ''))


### PR DESCRIPTION
Hi,

I've had this error earlier in a French Windows environment:

```Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/gevent/greenlet.py", line 536, in run
    result = self._run(*self.args, **self.kwargs)
  File "/usr/lib/python2.7/site-packages/crackmapexec-4.0.0.dev0-py2.7.egg/cme/protocols/smb.py", line 112, in __init__
    connection.__init__(self, args, db, host)
  File "/usr/lib/python2.7/site-packages/crackmapexec-4.0.0.dev0-py2.7.egg/cme/connection.py", line 39, in __init__
    self.proto_flow()
  File "/usr/lib/python2.7/site-packages/crackmapexec-4.0.0.dev0-py2.7.egg/cme/connection.py", line 75, in proto_flow
    self.call_cmd_args()
  File "/usr/lib/python2.7/site-packages/crackmapexec-4.0.0.dev0-py2.7.egg/cme/connection.py", line 82, in call_cmd_args
    getattr(self, k)()
  File "/usr/lib/python2.7/site-packages/crackmapexec-4.0.0.dev0-py2.7.egg/cme/connection.py", line 16, in _decorator
    return func(self, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/crackmapexec-4.0.0.dev0-py2.7.egg/cme/protocols/smb.py", line 85, in _decorator
    output = func(self, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/crackmapexec-4.0.0.dev0-py2.7.egg/cme/protocols/smb.py", line 426, in execute
    output = u'{}'.format(exec_method.execute(payload, get_output).strip().decode('utf-8'))
  File "/usr/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xff in position 69: invalid start byte
Tue Jun 13 14:45:38 2017 <Greenlet at 0x7f7c8900dd70: smb(Namespace(content=False, cred_id=[], darrell=False, <protocol.database instance at 0x7f7c8f1c6cb0>, '10.10.10.10')> failed with UnicodeDecodeError
```

The initial command was: 
```
sudo crackmapexec smb -u someuser -p somepass -d somedomain -x "tasklist | findstr /I outloo" 10.10.10.0/24
```

The attached commit did fix the error. I found that some special char is printed but I didn't dig which one. I believe that replacing unprintable characters is a desired behavior for this part but I will let you judge.

![image](https://user-images.githubusercontent.com/4238786/27100897-a5916f28-504d-11e7-8662-4eb5cd33dbc8.png)

Thank you for this awesome project.

