### PR TITLE
Don't make SMBEXEC service creation use "Auto Start"

### DIFF
--- a/cme/protocols/smb/smbexec.py
+++ b/cme/protocols/smb/smbexec.py
@@ -90,12 +90,15 @@ class SMBEXEC:
         logging.debug('Command to execute: ' + command)
 
         resp = scmr.hRCreateServiceW(self.__scmr, self.__scHandle, self.__serviceName, self.__serviceName, lpBinaryPathName=command)
+        logging.debug('Remote service {} created.'.format(self.__serviceName))
         service = resp['lpServiceHandle']
 
         try:
-           scmr.hRStartServiceW(self.__scmr, service)
+            logging.debug('Remote service {} started.'.format(self.__serviceName))
+            scmr.hRStartServiceW(self.__scmr, service)
         except:
            pass
+        logging.debug('Remote service {} deleted.'.format(self.__serviceName))
         scmr.hRDeleteService(self.__scmr, service)
         scmr.hRCloseServiceHandle(self.__scmr, service)
         self.get_output_fileless()

--- a/cme/protocols/smb/smbexec.py
+++ b/cme/protocols/smb/smbexec.py
@@ -89,8 +89,8 @@ class SMBEXEC:
         command = self.__shell + '\\\\{}\\{}\\{}'.format(local_ip,self.__share_name, self.__batchFile)
         logging.debug('Command to execute: ' + command)
 
-        resp = scmr.hRCreateServiceW(self.__scmr, self.__scHandle, self.__serviceName, self.__serviceName, lpBinaryPathName=command)
         logging.debug('Remote service {} created.'.format(self.__serviceName))
+        resp = scmr.hRCreateServiceW(self.__scmr, self.__scHandle, self.__serviceName, self.__serviceName, lpBinaryPathName=command, dwStartType=scmr.SERVICE_DEMAND_START)
         service = resp['lpServiceHandle']
 
         try:


### PR DESCRIPTION
`smbexec.py` uses `scmr.hRCreateServiceW()` without specifying a `dwStartType` argument which then defaults to `SERVICE_AUTO_START`. This is problematic when the command launched through smbexec does not return (ie through user-exit interaction or if the AV kills the service launch which results in the script never returning), resulting in the newly created service to persist on the host machine. This service is then launched everytime the system reboots, which creates undesired persistence. 

I simply changed the flag to `SERVICE_DEMAND_START`. This way, created services do not get executed across reboots. 

I also added debug information on service creation, execution and delete.