### PR TITLE
Changes to --users and --groups

### DIFF
--- a/cme/crackmapexec.py
+++ b/cme/crackmapexec.py
@@ -44,7 +44,7 @@ def main():
 
     cme_path = os.path.expanduser('~/.cme')
 
-    config = ConfigParser()
+    config = ConfigParser({'pwn3d_label': 'Pwn3d!'})
     config.read(os.path.join(cme_path, 'cme.conf'))
 
     module  = None
@@ -133,6 +133,8 @@ def main():
     db_connection.text_factory = str
     db_connection.isolation_level = None
     db = protocol_db_object(db_connection)
+
+    setattr(protocol_object, 'config', config)
 
     if hasattr(args, 'module'):
 

--- a/cme/protocols/mssql.py
+++ b/cme/protocols/mssql.py
@@ -19,11 +19,6 @@ class mssql(connection):
         self.domain = None
         self.hash = None
 
-        cme_path = os.path.expanduser('~/.cme')
-        config = ConfigParser({'pwn3d_label': 'Pwn3d!'})
-        config.read(os.path.join(cme_path, 'cme.conf'))
-        self.pwn3d = config.get('CME','pwn3d_label')
-
         connection.__init__(self, args, db, host)
 
     @staticmethod
@@ -178,7 +173,8 @@ class mssql(connection):
         out = u'{}{}:{} {}'.format('{}\\'.format(domain.decode('utf-8')) if self.args.auth_type is 'windows' else '',
                                      username.decode('utf-8'),
                                      password.decode('utf-8'),
-                                     highlight('('+self.pwn3d+')') if self.admin_privs else '')
+                                     highlight('('+self.config.get('CME','pwn3d_label')+')') if self.admin_privs else '')
+
 
         self.logger.success(out)
 
@@ -211,7 +207,7 @@ class mssql(connection):
         out = u'{}\\{} {} {}'.format(domain.decode('utf-8'),
                                      username.decode('utf-8'),
                                      ntlm_hash,
-                                     highlight('('+self.pwn3d+')') if self.admin_privs else '')
+                                     highlight('('+self.config.get('CME','pwn3d_label')+')') if self.admin_privs else '')
 
         self.logger.success(out)
 

--- a/cme/protocols/mssql.py
+++ b/cme/protocols/mssql.py
@@ -20,7 +20,7 @@ class mssql(connection):
         self.hash = None
 
         cme_path = os.path.expanduser('~/.cme')
-        config = ConfigParser({'pwn3d_label': 'Pwned!'})
+        config = ConfigParser({'pwn3d_label': 'Pwn3d!'})
         config.read(os.path.join(cme_path, 'cme.conf'))
         self.pwn3d = config.get('CME','pwn3d_label')
 

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -107,7 +107,7 @@ class smb(connection):
         self.smb_share_name = smb_share_name
 
         cme_path = os.path.expanduser('~/.cme')
-        config = ConfigParser({'pwn3d_label': 'Pwned!'})
+        config = ConfigParser({'pwn3d_label': 'Pwn3d!'})
         config.read(os.path.join(cme_path, 'cme.conf'))
         self.pwn3d = config.get('CME','pwn3d_label')
 

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -106,11 +106,6 @@ class smb(connection):
         self.signing = False
         self.smb_share_name = smb_share_name
 
-        cme_path = os.path.expanduser('~/.cme')
-        config = ConfigParser({'pwn3d_label': 'Pwn3d!'})
-        config.read(os.path.join(cme_path, 'cme.conf'))
-        self.pwn3d = config.get('CME','pwn3d_label')
-
         connection.__init__(self, args, db, host)
 
     @staticmethod
@@ -264,7 +259,7 @@ class smb(connection):
             out = u'{}\\{}:{} {}'.format(domain.decode('utf-8'),
                                          username.decode('utf-8'),
                                          password.decode('utf-8'),
-                                         highlight('('+self.pwn3d+')') if self.admin_privs else '')
+                                         highlight('('+self.config.get('CME','pwn3d_label')+')') if self.admin_privs else '')
 
             self.logger.success(out)
             return True
@@ -308,7 +303,7 @@ class smb(connection):
             out = u'{}\\{} {} {}'.format(domain.decode('utf-8'),
                                          username.decode('utf-8'),
                                          ntlm_hash,
-                                         highlight('('+self.pwn3d+')') if self.admin_privs else '')
+                                         highlight('('+self.config.get('CME','pwn3d_label')+')') if self.admin_privs else '')
 
             self.logger.success(out)
             return True

--- a/cme/protocols/ssh.py
+++ b/cme/protocols/ssh.py
@@ -9,12 +9,6 @@ from ConfigParser import ConfigParser
 
 class ssh(connection):
 
-    def __init__(self, args, db, host):
-        cme_path = os.path.expanduser('~/.cme')
-        config = ConfigParser({'pwn3d_label': 'Pwn3d!'})
-        config.read(os.path.join(cme_path, 'cme.conf'))
-        self.pwn3d = config.get('CME','pwn3d_label')
-
     @staticmethod
     def proto_args(parser, std_parser, module_parser):
         ssh_parser = parser.add_parser('ssh', help="own stuff using SSH", parents=[std_parser, module_parser])
@@ -66,7 +60,7 @@ class ssh(connection):
 
             self.logger.success(u'{}:{} {}'.format(username.decode('utf-8'),
                                                    password.decode('utf-8'),
-                                                   highlight('('+self.pwn3d+')') if self.admin_privs else ''))
+                                                   highlight('('+self.config.get('CME','pwn3d_label')+')') if self.admin_privs else ''))
 
             return True
         except Exception as e:

--- a/cme/protocols/ssh.py
+++ b/cme/protocols/ssh.py
@@ -11,7 +11,7 @@ class ssh(connection):
 
     def __init__(self, args, db, host):
         cme_path = os.path.expanduser('~/.cme')
-        config = ConfigParser({'pwn3d_label': 'Pwned!'})
+        config = ConfigParser({'pwn3d_label': 'Pwn3d!'})
         config.read(os.path.join(cme_path, 'cme.conf'))
         self.pwn3d = config.get('CME','pwn3d_label')
 

--- a/cme/protocols/winrm.py
+++ b/cme/protocols/winrm.py
@@ -20,7 +20,7 @@ class winrm(connection):
         self.domain = None
 
         cme_path = os.path.expanduser('~/.cme')
-        config = ConfigParser({'pwn3d_label': 'Pwned!'})
+        config = ConfigParser({'pwn3d_label': 'Pwn3d!'})
         config.read(os.path.join(cme_path, 'cme.conf'))
         self.pwn3d = config.get('CME','pwn3d_label')
 

--- a/cme/protocols/winrm.py
+++ b/cme/protocols/winrm.py
@@ -19,11 +19,6 @@ class winrm(connection):
     def __init__(self, args, db, host):
         self.domain = None
 
-        cme_path = os.path.expanduser('~/.cme')
-        config = ConfigParser({'pwn3d_label': 'Pwn3d!'})
-        config.read(os.path.join(cme_path, 'cme.conf'))
-        self.pwn3d = config.get('CME','pwn3d_label')
-
         connection.__init__(self, args, db, host)
 
     @staticmethod
@@ -125,7 +120,7 @@ class winrm(connection):
             self.logger.success(u'{}\\{}:{} {}'.format(self.domain.decode('utf-8'),
                                                        username.decode('utf-8'),
                                                        password.decode('utf-8'),
-                                                       highlight('('+self.pwn3d+')')))
+                                                       highlight('('+self.config.get('CME','pwn3d_label')+')')))
 
             return True
 


### PR DESCRIPTION
users() was failing on a bad attribute, changed code to use getattr
instead. If attribute is missing, it no longer throws exception.

extraction of domain from distinguished name was not working in all
circumstances. FOO.COM would work, but FOO.CO.UK or even FOO.BAR.CO.UK
would extract CO incorrectly. function now extracts fully qualified
domain, which then gets shortened by db_add_user() function.