### PR TITLE
Naming the locally generated SMB share

### DIFF
--- a/cme/helpers/misc.py
+++ b/cme/helpers/misc.py
@@ -20,6 +20,8 @@ def identify_target_file(target_file):
 def gen_random_string(length=10):
     return ''.join(random.sample(string.ascii_letters, int(length)))
 
+def gen_random_int(min=5, max=8):
+    return random.randint(min,max)
 
 def validate_ntlm(data):
     allowed = re.compile("^[0-9a-f]{32}", re.IGNORECASE)


### PR DESCRIPTION
I added the ability to name the local share that is spawned to help execute an attack when working with the SMB protocol.

The '--share' parameter was renamed to '--remote-share' and the '--local-share parameter was added. Added the logic needed to make use of this 'local' share name and a slight modification to the auto-generated share name when the --local-share parameter is not used. 

A helper function was added to helpers/misc.py that is used at the top of protocols/smb.py. 

Snoochy boochies!