### PR TITLE
connectback-host option

### DIFF
--- a/cme/cli.py
+++ b/cme/cli.py
@@ -62,6 +62,8 @@ def gen_cli_args():
     module_parser.add_argument("--server", choices={'http', 'https'}, default='https', help='use the selected server (default: https)')
     module_parser.add_argument("--server-host", type=str, default='0.0.0.0', metavar='HOST', help='IP to bind the server to (default: 0.0.0.0)')
     module_parser.add_argument("--server-port", metavar='PORT', type=int, help='start the server on the specified port')
+    module_parser.add_argument("--connectback-host", type=str, default='0.0.0.0', metavar='CHOST', help='IP for the remote system to connect back to (default: same as server-host)')
+#    module_parser.add_argument("--connectback-port", metavar='CPORT', type=int, help='port for the remote system to connect back to (default: same as server-port')
 
     for protocol in protocols.keys():
         protocol_object = p_loader.load_protocol(protocols[protocol]['path'])

--- a/cme/cli.py
+++ b/cme/cli.py
@@ -63,7 +63,6 @@ def gen_cli_args():
     module_parser.add_argument("--server-host", type=str, default='0.0.0.0', metavar='HOST', help='IP to bind the server to (default: 0.0.0.0)')
     module_parser.add_argument("--server-port", metavar='PORT', type=int, help='start the server on the specified port')
     module_parser.add_argument("--connectback-host", type=str, default='0.0.0.0', metavar='CHOST', help='IP for the remote system to connect back to (default: same as server-host)')
-#    module_parser.add_argument("--connectback-port", metavar='CPORT', type=int, help='port for the remote system to connect back to (default: same as server-port')
 
     for protocol in protocols.keys():
         protocol_object = p_loader.load_protocol(protocols[protocol]['path'])

--- a/cme/connection.py
+++ b/cme/connection.py
@@ -92,8 +92,8 @@ class connection(object):
                                          })
 
         context = Context(self.db, module_logger, self.args)
-        if 'CHOST' in module_options:
-           context.localip  = module_options['CHOST']
+        if self.args.connectback_host:
+           context.localip  = self.args.connectback_host
         else:
            context.localip  = self.local_ip
 

--- a/cme/connection.py
+++ b/cme/connection.py
@@ -92,7 +92,10 @@ class connection(object):
                                          })
 
         context = Context(self.db, module_logger, self.args)
-        context.localip  = self.local_ip
+        if 'CHOST' in module_options:
+           context.localip  = module_options['CHOST']
+        else:
+           context.localip  = self.local_ip
 
         if hasattr(self.module, 'on_request') or hasattr(self.module, 'has_response'):
             self.server.connection = self


### PR DESCRIPTION
Add a connect back IP module option to be sent to the remote system

This IP can be different to the local IP used for binding

This is necessary for situations where CME is behind NAT and port forwarding has to be used for target systems to connect back to CME.

Successfully tested with the mimikatz module.