### PR TITLE
Add credential import from Metasploit REST API

### DIFF
--- a/cme/cmedb.py
+++ b/cme/cmedb.py
@@ -312,9 +312,9 @@ class DatabaseNavigator(cmd.Cmd):
 
         d = dictionary
         for key in keys:
-            try:
+            if key in d:
                 d = d[key]
-            except KeyError:
+            else:
                 return False
         return True
 

--- a/cme/cmedb.py
+++ b/cme/cmedb.py
@@ -21,6 +21,9 @@ class UserExitedProto(Exception):
 
 
 class DatabaseNavigator(cmd.Cmd):
+    MSF_PASSWORD_TYPE = 'Metasploit::Credential::Password'
+    MSF_NTLM_HASH_TYPE = 'Metasploit::Credential::NTLMHash'
+    MSF_REALM_ACTIVE_DIRECTORY_DOMAIN = 'Active Directory Domain'
 
     def __init__(self, main_menu, database, proto):
         cmd.Cmd.__init__(self)
@@ -193,10 +196,6 @@ class DatabaseNavigator(cmd.Cmd):
         print '[+] Metasploit credential import successful'
 
     def metasploit_api_import(self):
-        MSF_PASSWORD_TYPE = 'Metasploit::Credential::Password'
-        MSF_NTLM_HASH_TYPE = 'Metasploit::Credential::NTLMHash'
-        MSF_REALM_ACTIVE_DIRECTORY_DOMAIN = 'Active Directory Domain'
-
         # get workspace name from the config file, otherwise use CME workspace name
         if self.config.has_option('Metasploit', 'workspace'):
             workspace = self.config.get('Metasploit', 'workspace')
@@ -245,7 +244,7 @@ class DatabaseNavigator(cmd.Cmd):
             # get credentials
             cred_query = {
                 'workspace': workspace,
-                'type[]': [MSF_PASSWORD_TYPE, MSF_NTLM_HASH_TYPE]
+                'type[]': [self.MSF_PASSWORD_TYPE, self.MSF_NTLM_HASH_TYPE]
             }
             r = requests.get(base_url + '/api/v1/credentials', params=cred_query,
                              headers=headers, verify=False)
@@ -259,9 +258,9 @@ class DatabaseNavigator(cmd.Cmd):
                 for cred in creds['data']:
                     # map Metasploit cred type to CME
                     if self.keys_exist(cred, 'private', 'type'):
-                        if cred['private']['type'] == MSF_PASSWORD_TYPE:
+                        if cred['private']['type'] == self.MSF_PASSWORD_TYPE:
                             cred_type = 'plaintext'
-                        elif cred['private']['type'] == MSF_NTLM_HASH_TYPE:
+                        elif cred['private']['type'] == self.MSF_NTLM_HASH_TYPE:
                             cred_type = 'hash'
                         else:
                             # skip credential
@@ -272,7 +271,7 @@ class DatabaseNavigator(cmd.Cmd):
 
                     # get domain
                     if (self.keys_exist(cred, 'realm', 'key') and
-                            cred['realm']['key'] == MSF_REALM_ACTIVE_DIRECTORY_DOMAIN and
+                            cred['realm']['key'] == self.MSF_REALM_ACTIVE_DIRECTORY_DOMAIN and
                             self.keys_exist(cred, 'realm', 'value')):
                         domain = cred['realm']['value']
                     else:

--- a/cme/cmedb.py
+++ b/cme/cmedb.py
@@ -86,80 +86,23 @@ class DatabaseNavigator(cmd.Cmd):
         else:
             print '[-] invalid argument, specify creds or hosts'
 
-
     def do_import(self, line):
         if not line:
+            print "[-] not enough arguments"
             return
 
-        if line == 'empire':
-            headers = {'Content-Type': 'application/json'}
+        line = line.split()
 
-            # Pull the username and password from the config file
-            payload = {'username': self.config.get('Empire', 'username'),
-                       'password': self.config.get('Empire', 'password')}
-
-            # Pull the host and port from the config file
-            base_url = 'https://{}:{}'.format(self.config.get('Empire', 'api_host'), self.config.get('Empire', 'api_port'))
-
-            try:
-                r = requests.post(base_url + '/api/admin/login', json=payload, headers=headers, verify=False)
-                if r.status_code == 200:
-                    token = r.json()['token']
-
-                    url_params = {'token': token}
-                    r = requests.get(base_url + '/api/creds', headers=headers, params=url_params, verify=False)
-                    creds = r.json()
-
-                    for cred in creds['creds']:
-                        if cred['credtype'] == 'token' or cred['credtype'] == 'krbtgt' or cred['username'].endswith('$'):
-                            continue
-
-                        self.db.add_credential(cred['credtype'], cred['domain'], cred['username'], cred['password'])
-
-                    print "[+] Empire credential import successful"
-                else:
-                    print "[-] Error authenticating to Empire's RESTful API server!"
-
-            except ConnectionError as e:
-                print "[-] Unable to connect to Empire's RESTful API server: {}".format(e)
-
-        elif line == 'metasploit':
-            msf = Msfrpc({'host': self.config.get('Metasploit', 'rpc_host'),
-                          'port': self.config.get('Metasploit', 'rpc_port')})
-
-            try:
-                msf.login('msf', self.config.get('Metasploit', 'password'))
-            except MsfAuthError:
-                print "[-] Error authenticating to Metasploit's MSGRPC server!"
+        if line[0].lower() == 'empire':
+            self.empire_api_import()
+        elif line[0].lower() == 'metasploit':
+            if len(line) > 2 or line[1].lower() not in ['rpc', 'api']:
+                print "[-] invalid arguments, import metasploit <rpc|api>"
                 return
-
-            console_id = str(msf.call('console.create')['id'])
-
-            msf.call('console.write', [console_id, 'creds\n'])
-
-            sleep(2)
-
-            creds = msf.call('console.read', [console_id])
-
-            for entry in creds['data'].split('\n'):
-                cred = entry.split()
-                try:
-                    # host = cred[0]
-                    # port = cred[2]
-                    proto = cred[3]
-                    username = cred[4]
-                    password = cred[5]
-                    cred_type = cred[6]
-
-                    if proto == '({})'.format(self.proto) and cred_type == 'Password':
-                        self.db.add_credential('plaintext', '', username, password)
-
-                except IndexError:
-                    continue
-
-            msf.call('console.destroy', [console_id])
-
-            print "[+] Metasploit credential import successful"
+            elif line[1].lower() == 'rpc':
+                self.metasploit_rpc_import()
+            elif line[1].lower() == 'api':
+                self.metasploit_api_import()
 
     def complete_import(self, text, line, begidx, endidx):
         "Tab-complete 'import' commands."
@@ -178,6 +121,203 @@ class DatabaseNavigator(cmd.Cmd):
         mline = line.partition(' ')[2]
         offs = len(mline) - len(text)
         return [s[offs:] for s in commands if s.startswith(mline)]
+
+    def empire_api_import(self):
+        headers = {'Content-Type': 'application/json'}
+
+        # Pull the username and password from the config file
+        payload = {'username': self.config.get('Empire', 'username'),
+                   'password': self.config.get('Empire', 'password')}
+
+        # Pull the host and port from the config file
+        base_url = 'https://{}:{}'.format(self.config.get('Empire', 'api_host'), self.config.get('Empire', 'api_port'))
+
+        try:
+            r = requests.post(base_url + '/api/admin/login', json=payload, headers=headers, verify=False)
+            if r.status_code == 200:
+                token = r.json()['token']
+
+                url_params = {'token': token}
+                r = requests.get(base_url + '/api/creds', headers=headers, params=url_params, verify=False)
+                creds = r.json()
+
+                for cred in creds['creds']:
+                    if cred['credtype'] == 'token' or cred['credtype'] == 'krbtgt' or cred['username'].endswith('$'):
+                        continue
+
+                    self.db.add_credential(cred['credtype'], cred['domain'], cred['username'], cred['password'])
+
+                print '[+] Empire credential import successful'
+            else:
+                print "[-] Error authenticating to Empire's RESTful API server!"
+
+        except ConnectionError as e:
+            print "[-] Unable to connect to Empire's RESTful API server: {}".format(e)
+
+    def metasploit_rpc_import(self):
+        msf = Msfrpc({'host': self.config.get('Metasploit', 'rpc_host'),
+                      'port': self.config.get('Metasploit', 'rpc_port')})
+
+        try:
+            msf.login('msf', self.config.get('Metasploit', 'password'))
+        except MsfAuthError:
+            print "[-] Error authenticating to Metasploit's MSGRPC server!"
+            return
+
+        console_id = str(msf.call('console.create')['id'])
+
+        msf.call('console.write', [console_id, 'creds\n'])
+
+        sleep(2)
+
+        creds = msf.call('console.read', [console_id])
+
+        for entry in creds['data'].split('\n'):
+            cred = entry.split()
+            try:
+                # host = cred[0]
+                # port = cred[2]
+                proto = cred[3]
+                username = cred[4]
+                password = cred[5]
+                cred_type = cred[6]
+
+                if proto == '({})'.format(self.proto) and cred_type == 'Password':
+                    self.db.add_credential('plaintext', '', username, password)
+
+            except IndexError:
+                continue
+
+        msf.call('console.destroy', [console_id])
+
+        print '[+] Metasploit credential import successful'
+
+    def metasploit_api_import(self):
+        MSF_PASSWORD_TYPE = 'Metasploit::Credential::Password'
+        MSF_NTLM_HASH_TYPE = 'Metasploit::Credential::NTLMHash'
+        MSF_REALM_ACTIVE_DIRECTORY_DOMAIN = 'Active Directory Domain'
+
+        # get workspace name from the config file, otherwise use CME workspace name
+        if self.config.has_option('Metasploit', 'workspace'):
+            workspace = self.config.get('Metasploit', 'workspace')
+        else:
+            workspace = self.main_menu.workspace
+
+        # get the API token from the config file
+        headers = {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer {}'.format(self.config.get('Metasploit', 'api_token'))
+        }
+
+        # get the API base URL from the config file
+        base_url = self.config.get('Metasploit', 'api_base_url')
+
+        try:
+            # check for valid API server
+            r = requests.get(base_url + '/api/v1/msf/version', headers=headers, verify=False)
+            if r.status_code == 401:
+                print "[-] Error authenticating to Metasploit's RESTful API server"
+                return
+            elif r.status_code != 200:
+                print "[-] Error: {} doesn't appear to be a valid Metasploit RESTful API server".format(base_url)
+                return
+
+            # check that the workspace exists
+            r = requests.get(base_url + '/api/v1/workspaces', params={'name': workspace},
+                             headers=headers, verify=False)
+            if r.status_code == 401:
+                print "[-] Error authenticating to Metasploit's RESTful API server"
+                return
+            elif r.status_code != 200:
+                print "[-] Error: invalid workspace '{}'".format(workspace)
+                print "[-] Status Code: {} ({}), Content: {}".format(r.status_code, r.reason, r.text)
+                return
+            else:
+                # process workspace query response
+                workspaces_response = r.json()
+                if (not self.keys_exist(workspaces_response, 'data') or
+                        len(workspaces_response['data']) != 1):
+                    print "[-] Error: invalid workspace '{}'".format(workspace)
+                    return
+
+            print "[+] Metasploit workspace '{}' exists".format(workspace)
+
+            # get credentials
+            cred_query = {
+                'workspace': workspace,
+                'type[]': [MSF_PASSWORD_TYPE, MSF_NTLM_HASH_TYPE]
+            }
+            r = requests.get(base_url + '/api/v1/credentials', params=cred_query,
+                             headers=headers, verify=False)
+            if r.status_code == 200:
+                creds = r.json()
+                if not creds.get('data'):
+                    print "[-] Error: credentials response missing data object"
+                    print "[-] Content: {}".format(r.text)
+                    return
+
+                for cred in creds['data']:
+                    # map Metasploit cred type to CME
+                    if self.keys_exist(cred, 'private', 'type'):
+                        if cred['private']['type'] == MSF_PASSWORD_TYPE:
+                            cred_type = 'plaintext'
+                        elif cred['private']['type'] == MSF_NTLM_HASH_TYPE:
+                            cred_type = 'hash'
+                        else:
+                            # skip credential
+                            continue
+                    else:
+                        # skip credential
+                        continue
+
+                    # get domain
+                    if (self.keys_exist(cred, 'realm', 'key') and
+                            cred['realm']['key'] == MSF_REALM_ACTIVE_DIRECTORY_DOMAIN and
+                            self.keys_exist(cred, 'realm', 'value')):
+                        domain = cred['realm']['value']
+                    else:
+                        domain = ''
+
+                    # get username
+                    if self.keys_exist(cred, 'public', 'username'):
+                        username = cred['public']['username']
+                    else:
+                        username = ''
+
+                    # get password
+                    if self.keys_exist(cred, 'private', 'data'):
+                        password = cred['private']['data']
+                    else:
+                        password = ''
+
+                    self.db.add_credential(cred_type, domain, username, password)
+
+                print "[+] Metasploit credential import successful"
+
+            elif r.status_code == 401:
+                print "[-] Error authenticating to Metasploit's RESTful API server"
+            else:
+                print "[-] Error: failed to get credentials from Metasploit's RESTful API server"
+                print "[-] Status Code: {} ({}), Content: {}".format(r.status_code, r.reason, r.text)
+
+        except ConnectionError as e:
+            print "[-] Unable to connect to Metasploit's RESTful API server: {}".format(e)
+
+    @staticmethod
+    def keys_exist(dictionary, *keys):
+        """Checks that all *keys exist nested within dictionary."""
+        if type(dictionary) is not dict:
+            raise TypeError('dictionary is not a dict type')
+        if len(keys) == 0:
+            raise ValueError('one or more values required in *keys')
+
+        d = dictionary
+        for key in keys:
+            try:
+                d = d[key]
+            except KeyError:
+                return False
+        return True
 
 
 class CMEDBMenu(cmd.Cmd):

--- a/cme/data/cme.conf
+++ b/cme/data/cme.conf
@@ -13,3 +13,5 @@ password=Password123!
 rpc_host=127.0.0.1
 rpc_port=55552
 password=abc123
+api_base_url=https://localhost:8080
+api_token=TOKEN


### PR DESCRIPTION
This adds the option to import credentials from Metasploit's REST API using `cmedb`. The `import metasploit` command has been enhanced with an additional argument to allow the user to provide the method of import from Metasploit, `import metasploit <rpc|api>`. If the argument is left off `import metasploit`, it defaults to `rpc` to avoid disturbing any existing workflows. However, it would be nice to see this removed eventually. The Metasploit workspace credentials are imported from may be specified using a `workspace` option in the Metasploit section of the config file. If this option is not provided it will default to the current CME workspace name.

## Verification

- [x] Install Metasploit Framework MSF5 (master branch)
    - [ ] See [Setting Up a Metasploit Development Environment](https://github.com/rapid7/metasploit-framework/wiki/Setting-Up-a-Metasploit-Development-Environment) until the MSF5 Nightly Installers are available.
- [ ] Run `msfdb init` to initialize both the database and web service
- [ ] Note the web service API token that is provided when the script completes
- [ ] **Verify** MSF database and web service are running
    - [ ] Execute `msfdb status`, the status should report that both database and web service are running
    - [ ] Execute `curl --insecure -H "Accept: application/json" -H "Authorization: Bearer <token>" https://localhost:8080/api/v1/msf/version | python -m json.tool` and you should see a response that contains the Metasploit version.
- [ ] Start `msfconsole` and create creds (see `creds -h` or run modules that will result in credentials being created)
- [ ] Edit `~/.cme/cme.conf` and configure it appropriately based on how you started the MSF web service earlier using `msfdb`
    ```
    [Metasploit]
    ...
    api_base_url = https://localhost:8080
    api_token = TOKEN
    ```
- [ ] Run `cme` to initialize databases
- [ ] Start `cmedb`
- [ ] Run command `proto smb`
- [ ] Run command `creds` and note that no creds are present if using a fresh database
- [ ] Run command `import metasploit api`
- [ ] Run command `creds`
- [ ] **Verify** NTLM hash and Password credentials from Metasploit are now present in the CME database

## Example

### Metasploit
```
msf5 > creds
Credentials
===========

host  origin  service  public                private                                                            realm              private_type
----  ------  -------  ------                -------                                                            -----              ------------
                       admin                 notpassword                                                        workgroup          Password
                       admin-wildcard-realm  notpassword123                                                     dont-know-or-care  Password
                                             password without username                                                             Password
                       other                 d19c32489b870735b5f587d76b934283                                                      Nonreplayable hash
                       guest                 guest password                                                                        Password
                       admin                 e2fc15074bf7751dd408e6b105741864:a1074a69b1bde45403ab680504bbdd1a                     NTLM hash
```

### CrackMapExec
```
cmedb (default) > proto smb
cmedb (default)(smb) > creds

+Credentials--------+----------+--------+----------+----------+
| CredID | Admin On | CredType | Domain | UserName | Password |
+--------+----------+----------+--------+----------+----------+

cmedb (default)(smb) > import metasploit api
[+] Metasploit workspace 'default' exists
[+] Metasploit credential import successful
cmedb (default)(smb) > creds

+Credentials---------+-----------+-----------+----------------------+-------------------------------------------------------------------+
| CredID | Admin On  | CredType  | Domain    | UserName             | Password                                                          |
+--------+-----------+-----------+-----------+----------------------+-------------------------------------------------------------------+
| 1      | 0 Host(s) | plaintext | WORKGROUP | admin                | notpassword                                                       |
| 2      | 0 Host(s) | plaintext |           | guest                | guest password                                                    |
| 3      | 0 Host(s) | plaintext |           |                      | password without username                                         |
| 4      | 0 Host(s) | hash      |           | admin                | e2fc15074bf7751dd408e6b105741864:a1074a69b1bde45403ab680504bbdd1a |
| 5      | 0 Host(s) | plaintext |           | admin-wildcard-realm | notpassword123                                                    |
+--------+-----------+-----------+-----------+----------------------+-------------------------------------------------------------------+
```
