### PR TITLE
adding shabang

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 from setuptools import setup, find_packages
 
 setup(name='crackmapexec',


### PR DESCRIPTION
shabang declaration allows simpler ./setup.py execution on command line which matches existing executable permissions on setup file, rather than requiring 'python setup.py' execution