### PR TITLE
Fix false positive signing disabled with SMB2/3

### DIFF
--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -209,7 +209,7 @@ class smb(connection):
         self.domain    = self.conn.getServerDomain()
         self.hostname  = self.conn.getServerName()
         self.server_os = self.conn.getServerOS()
-        self.signing   = self.conn.isSigningRequired()
+        self.signing   = self.conn.isSigningRequired() if self.smbv1 else self.conn._SMBConnection._Connection['RequireSigning']
         self.os_arch   = self.get_os_arch()
 
         self.output_filename = os.path.expanduser('~/.cme/logs/{}_{}_{}'.format(self.hostname, self.host, datetime.now().strftime("%Y-%m-%d_%H%M%S")))


### PR DESCRIPTION
Currently, the `SMBConnection.isSigningRequired` and `SMB3.is_signing_required` methods in Impacket reflect the state of the session as opposed to the state of the connection.  When using CME with the `--gen-relay-list` option, the `SMB3.login` method would encounter an exception near the end, and would reset the session state.  Afterwards, the connection state correctly showed that signing was required, but the session state claimed the opposite.  The latter contributed to many false positives in the `--gen-relay-list` output file.  This is a hackish change that addressed the issue for me.