### PR TITLE
Fix encoding in smb --sam

### DIFF
--- a/cme/protocols/smb/database.py
+++ b/cme/protocols/smb/database.py
@@ -141,8 +141,8 @@ class database:
 
         cur.close()
 
-        logging.debug('add_credential(credtype={}, domain={}, username={}, password={}, groupid={}, pillaged_from={}) => {}'.format(credtype, domain, username, password,
-                                                                                                                                    groupid, pillaged_from, user_rowid))
+        logging.debug('add_credential(credtype={}, domain={}, username={}, password={}, groupid={}, pillaged_from={}) => {}'.encode().format(credtype, domain, username, password,
+                                                                                                                                             groupid, pillaged_from, user_rowid))
 
         return user_rowid
 


### PR DESCRIPTION
Small Pull Request for fixing encoding with the "é" character (but not only) with `--sam` and smb.

Logs of error : 

```
(CrackMapExec) ➜  CrackMapExec git:(master) cme smb A.B.C.D -u someuser -p somepassword --local-auth --sam                                                                                          
SMB         A.B.C.D   445    SOMESERVER  [*] Some version (name:SOMESERVER) (domain:SOMESERVER) (signing:False) (SMBv1:True)
SMB         A.B.C.D   445    SOMESERVER  [+] SOMESERVER\someuser:somepassword (Pwn3d!)
SMB         A.B.C.D   445    SOMESERVER  [+] Dumping SAM hashes
SMB         A.B.C.D   445    SOMESERVER  foo:xxx:yyy:zzzz:::
SMB         A.B.C.D   445    SOMESERVER  testwithé:xxx:yyy:zzz:::
Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 766, in gevent._greenlet.Greenlet.run
  File "/home/user/.local/share/virtualenvs/CrackMapExec-utN_odZW/local/lib/python2.7/site-packages/crackmapexec-4.0.1.dev0-py2.7.egg/cme/protocols/smb.py", line 110, in __init__
    connection.__init__(self, args, db, host)
  File "/home/user/.local/share/virtualenvs/CrackMapExec-utN_odZW/local/lib/python2.7/site-packages/crackmapexec-4.0.1.dev0-py2.7.egg/cme/connection.py", line 41, in __init__
    self.proto_flow()
  File "/home/user/.local/share/virtualenvs/CrackMapExec-utN_odZW/local/lib/python2.7/site-packages/crackmapexec-4.0.1.dev0-py2.7.egg/cme/connection.py", line 77, in proto_flow
    self.call_cmd_args()
  File "/home/user/.local/share/virtualenvs/CrackMapExec-utN_odZW/local/lib/python2.7/site-packages/crackmapexec-4.0.1.dev0-py2.7.egg/cme/connection.py", line 84, in call_cmd_args
    getattr(self, k)()
  File "/home/user/.local/share/virtualenvs/CrackMapExec-utN_odZW/local/lib/python2.7/site-packages/crackmapexec-4.0.1.dev0-py2.7.egg/cme/connection.py", line 17, in _decorator
    return func(self, *args, **kwargs)
  File "/home/user/.local/share/virtualenvs/CrackMapExec-utN_odZW/local/lib/python2.7/site-packages/crackmapexec-4.0.1.dev0-py2.7.egg/cme/protocols/smb.py", line 828, in sam
    SAM.dump()
  File "/home/user/.local/share/virtualenvs/CrackMapExec-utN_odZW/local/lib/python2.7/site-packages/crackmapexec-4.0.1.dev0-py2.7.egg/cme/thirdparty/impacket/impacket/examples/secretsdump.py", line 1260, in dump
    self.__perSecretCallback(answer)
  File "/home/user/.local/share/virtualenvs/CrackMapExec-utN_odZW/local/lib/python2.7/site-packages/crackmapexec-4.0.1.dev0-py2.7.egg/cme/protocols/smb.py", line 825, in <lambda>
    SAM = SAMHashes(SAMFileName, self.bootkey, isRemote=True, perSecretCallback=lambda secret: add_sam_hash(secret, host_id))
  File "/home/user/.local/share/virtualenvs/CrackMapExec-utN_odZW/local/lib/python2.7/site-packages/crackmapexec-4.0.1.dev0-py2.7.egg/cme/protocols/smb.py", line 819, in add_sam_hash
    self.db.add_credential('hash', self.hostname, username, ':'.join((lmhash, nthash)), pillaged_from=host_id)
  File "/home/user/.local/share/virtualenvs/CrackMapExec-utN_odZW/local/lib/python2.7/site-packages/crackmapexec-4.0.1.dev0-py2.7.egg/cme/protocols/smb/database.py", line 145, in add_credential
    groupid, pillaged_from, user_rowid))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 5: ordinal not in range(128)
2019-04-12T08:55:11Z <Greenlet at 0x7f45eef70890: smb(Namespace(clear_obfscripts=False, content=False, c, <protocol.database instance at 0x7f45eef1b4d0>, 'A.B.C.D')> failed with UnicodeEncodeError
```

You can test it easily with an user containing "é" in username.