### PR TITLE
lsa secrets: dump file extension

### DIFF
--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -864,7 +864,7 @@ class smb(connection):
             LSA.exportSecrets(self.output_filename)
 
             self.logger.success('Dumped {} LSA secrets to {} and {}'.format(highlight(add_lsa_secret.secrets),
-                                                                            self.output_filename + '.lsa', self.output_filename + '.cached'))
+                                                                            self.output_filename + '.secrets', self.output_filename + '.cached'))
 
             try:
                 self.remote_ops.finish()


### PR DESCRIPTION
The logger tell you LSA secrets are dump in a file named xxx.lsa

```
SMB        x.x.x.x 445    host       [+] Dumped 22 LSA secrets to /home/noraj/.cme/logs/host_x.x.x.x_2019-12-19_095552.lsa and /home/noraj/.cme/logs/host_x.x.x.x_2019-12-19_095552.cached
```

But in reality they are logged in xxx.screts.

So just fixing the extension showed by the  logger.