### PR TITLE
Fix file reading concurrency issues

### DIFF
--- a/cme/crackmapexec.py
+++ b/cme/crackmapexec.py
@@ -66,24 +66,6 @@ def main():
         else:
             jitter = (0, int(args.jitter))
 
-    if hasattr(args, 'username') and args.username:
-        for user in args.username:
-            if os.path.exists(user):
-                args.username.remove(user)
-                args.username.append(open(user, 'r'))
-
-    if hasattr(args, 'password') and args.password:
-        for passw in args.password:
-            if os.path.exists(passw):
-                args.password.remove(passw)
-                args.password.append(open(passw, 'r'))
-
-    elif hasattr(args, 'hash') and args.hash:
-        for ntlm_hash in args.hash:
-            if os.path.exists(ntlm_hash):
-                args.hash.remove(ntlm_hash)
-                args.hash.append(open(ntlm_hash, 'r'))
-
     if hasattr(args, 'cred_id') and args.cred_id:
         for cred_id in args.cred_id:
             if '-' in str(cred_id):


### PR DESCRIPTION
# Preface

I am not an experienced python programmer and I have not worked with greenlet before. If my changes look unpythonic or the fix shows a flawed understanding of greenlet, please let me know.

The code also doesn't exactly get prettier with my fixes, but I opted to fix the problem at hand instead of trying to refactor it simultaneously.

# Issue

I noticed that CME does not properly try all combinations when specifying multiple targets. To test this, I created the following files:
* `users1.txt` with the content
  ```
  one
  two
  three
  ```
* `passwords1.txt` with the content
  ```
  111
  222
  333
  ```

Then I ran CME in SMB brute force mode on two hosts. In the following screenshot you can see that host `.8` never receives the 3 guesses with username `two`, while host `.13` receives the guesses for that username twice!
![Bruteforce broken](https://user-images.githubusercontent.com/1112236/90334561-ccc5e600-dfce-11ea-9501-927c4736c865.png)

In `--no-bruteforce` mode it gets even worse:  `.8` never receives the one guess with username `two`, but gets attacked using the credentials `three:222` which should not happen. Host `.13` gets a single broken guess of `one:333` before CME enters an infinite loop (from seeking the user file while iterating over it). See the following screenshot:
![No bruteforce broken](https://user-images.githubusercontent.com/1112236/90334571-df401f80-dfce-11ea-9ba5-ffec5d4a5e17.png)

See the commit message for root cause analysis.

# Commit message
Before this commit, file objects for the username, password or NTLM hash files were all shared between target jobs for different hosts. This could cause numerous different errors in password or hash spraying jobs with multiple targets. Sometimes some lines in input files were skipped for some targets, and sometimes CME even ended up in an infinite loop due to seeking in a file that is currently also being iterated on.

There have been attempts to fix some of these errors with file.seek(0) in some places, such as with d13042f6375e98fe6a0cff6d3a23a48b4a84b4c7. This almost works because of the BoundedSemaphore sem that effectively keeps CME attacks single-threaded. However, there were still corner cases with shared file object accesses not protected by the semaphore.

To fix this in a reliable way, this commit shifts the responsibility of open()ing a file object to every job instead of globally at the start. While this does mean that the application will open the same files a bunch of times, it also ensures correctness in regard to concurrency. This should also allow to relax the semaphore in the future in case no global or username limit across all targets is required.