### PR TITLE
Fixed GPP filename typo and print

### DIFF
--- a/cme/modules/gpp_password.py
+++ b/cme/modules/gpp_password.py
@@ -43,7 +43,7 @@ class CMEModule:
                     elif 'Services.xml' in path:
                         xml_section = xml.findall('./NTService/Properties')
 
-                    elif 'Scheduledtasks.xml' in path:
+                    elif 'ScheduledTasks.xml' in path:
                         xml_section = xml.findall('./Task/Properties')
 
                     elif 'DataSources.xml' in path:
@@ -85,4 +85,4 @@ class CMEModule:
         password = b64decode(cpassword)
         IV = "\x00" * 16
         decypted = AES.new(key, AES.MODE_CBC, IV.encode("utf8")).decrypt(password)
-        return decypted.decode()
+        return decypted.decode().rstrip()


### PR DESCRIPTION
The gpp_password module contains a typo for the ScheduleTask.xml file type and fails to update the xml_section variable and find the stored password as a result. Additionally, the decrypt_cpassword() function leaves trailing newlines when returning the password.

Below is an example of the module printing the same credential twice when it should have been a different credential. Also, it shows the many newlines printed.
![Screen Shot 2020-09-02 at 11 13 37 AM](https://user-images.githubusercontent.com/18901000/92002158-88944e80-ed0d-11ea-8a1b-88ee1919c4c5.png)


Here is a screenshot with the proposed changes:
![Screen Shot 2020-09-02 at 11 09 54 AM](https://user-images.githubusercontent.com/18901000/92001752-115eba80-ed0d-11ea-8fc3-ba9687bf8770.png)
