### PR TITLE
Fix mssql execute command error

### DIFF
--- a/cme/helpers/powershell.py
+++ b/cme/helpers/powershell.py
@@ -19,7 +19,7 @@ def get_ps_script(path):
     return os.path.join(os.path.dirname(cme.__file__), 'data', path)
 
 def encode_ps_command(command):
-    return b64encode(command.encode('UTF-16LE'))
+    return b64encode(command.encode('UTF-16LE')).decode()
 
 def is_powershell_installed():
     if which('powershell'): 

--- a/cme/protocols/mssql.py
+++ b/cme/protocols/mssql.py
@@ -83,7 +83,7 @@ class mssql(connection):
                 try:
                     smb_conn.login('', '')
                 except SessionError as e:
-                    if "STATUS_ACCESS_DENIED" in e.message:
+                    if "STATUS_ACCESS_DENIED" in e.getErrorString():
                         pass
 
                 self.domain = smb_conn.getServerDNSDomainName()

--- a/cme/protocols/mssql.py
+++ b/cme/protocols/mssql.py
@@ -135,20 +135,12 @@ class mssql(connection):
 
     def check_if_admin(self, auth):
         try:
-            # I'm pretty sure there has to be a better way of doing this.
-            # Currently we are just searching for our user in the sysadmin group
-
-            self.conn.sql_query("EXEC sp_helpsrvrolemember 'sysadmin'")
+            self.conn.sql_query("SELECT IS_SRVROLEMEMBER('sysadmin')")
             self.conn.printRows()
             query_output = self.conn._MSSQL__rowsPrinter.getMessage()
-            logging.debug("'sysadmin' group members:\n{}".format(query_output))
+            query_output = query_output.strip("\n-")
 
-            if not auth:
-                search_string = '{}\\{}'.format(self.domain, self.username)
-            else:
-                search_string = self.username
-
-            if re.search(r'\b'+search_string+'\W', query_output):
+            if int(query_output):
                 self.admin_privs = True
             else:
                 return False


### PR DESCRIPTION
When I use `-d` with an FQDN domain name, the `-x` command cannot be executed.

The `offensive\dbadmin` user does exist in query_output, but check_if_admin cannot find it using the search_string `offensive.local\dbadmin`. 

```
proxychains4 -q python3 crackmapexec.py mssql 192.168.159.20 -d offensive.local -u dbadmin -p 'Passw0rd!' -x whoami
MSSQL       192.168.159.20  1433   None             [*] None (name:192.168.159.20) (domain:offensive.local)
MSSQL       192.168.159.20  1433   None             [+] offensive.local\dbadmin:Passw0rd!
```

I think the `IS_SRVROLEMEMBER` function can better check whether a user is sysadmin.

The commit 7dde1a1  fixed this issue. After the fix:

```
proxychains4 -q python3 crackmapexec.py mssql 192.168.159.20 -d offensive.local -u dbadmin -p 'Passw0rd!' -x whoami
MSSQL       192.168.159.20  1433   None             [*] None (name:192.168.159.20) (domain:offensive.local)
MSSQL       192.168.159.20  1433   None             [+] offensive.local\dbadmin:Passw0rd! (Pwn3d!)
MSSQL       192.168.159.20  1433   None             [+] Executed command via mssqlexec
MSSQL       192.168.159.20  1433   None             --------------------------------------------------------------------------------
MSSQL       192.168.159.20  1433   None             offensive\dbadmin
```


---


When using `-X` to execute a powershell command, I encounter another error.

```
proxychains4 -q python3 crackmapexec.py mssql 192.168.159.20 -d offensive -u dbadmin -p 'Passw0rd!' -X whoami
MSSQL       192.168.159.20  1433   None             [*] None (name:192.168.159.20) (domain:offensive)
MSSQL       192.168.159.20  1433   None             [+] offensive\dbadmin:Passw0rd! (Pwn3d!)
MSSQL       192.168.159.20  1433   None             [-] ERROR(SQL1\SQLEXPRESS): Line 1: The identifier that starts with 'WwBOAGUAdAAuAFMAZQByAHYAaQBjAGUAUABvAGkAbgB0AE0AYQBuAGEAZwBlAHIAXQA6ADoAUwBlAHIAdgBlAHIAQwBlAHIAdABpAGYAaQBjAGEAdABlAFYAYQBsAGkA' is too long. Maximum length is 128.
MSSQL       192.168.159.20  1433   None             [-] ERROR(SQL1\SQLEXPRESS): Line 1: Incorrect syntax near 'WwBOAGUAdAAuAFMAZQByAHYAaQBjAGUAUABvAGkAbgB0AE0AYQBuAGEAZwBlAHIAXQA6ADoAUwBlAHIAdgBlAHIAQwBlAHIAdABpAGYAaQBjAGEAdABlAFYAYQBsAGkA'.
MSSQL       192.168.159.20  1433   None             [+] Executed command via mssqlexec
MSSQL       192.168.159.20  1433   None             None
```

It is beacuse the type of the return value of b64encode is bytes, when using the bytes type to build the powershell command，you will get a wrong powershell command like `powershell.exe -noni -nop -w 1 -enc b'<base64-encoded string>'`

The commit 9f7a285 fixed this issue. After the fix:

```
proxychains4 -q python3 crackmapexec.py mssql 192.168.159.20 -d offensive -u dbadmin -p 'Passw0rd!' -X whoami
MSSQL       192.168.159.20  1433   None             [*] None (name:192.168.159.20) (domain:offensive)
MSSQL       192.168.159.20  1433   None             [+] offensive\dbadmin:Passw0rd! (Pwn3d!)
MSSQL       192.168.159.20  1433   None             [+] Executed command via mssqlexec
MSSQL       192.168.159.20  1433   None             --------------------------------------------------------------------------------
MSSQL       192.168.159.20  1433   None             offensive\dbadmin
```
