### PR TITLE
docs: fix simple typo, retreiving -> retrieving

### DIFF
--- a/cme/modules/bloodhound.py
+++ b/cme/modules/bloodhound.py
@@ -7,7 +7,7 @@ class CMEModule:
     '''
         Executes the BloodHound recon script on the target and retreives the results onto the attackers' machine
         2 supported modes :
-            CSV :           exports data into CSVs on the target file system before retreiving them (NOT opsec safe)
+            CSV :           exports data into CSVs on the target file system before retrieving them (NOT opsec safe)
             Neo4j API :     exports data directly to the Neo4j API (opsec safe)
 
         Module by Waffle-Wrath


### PR DESCRIPTION
There is a small typo in cme/modules/bloodhound.py.

Should read `retrieving` rather than `retreiving`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md