### PR TITLE
Add webdav module

### DIFF
--- a/cme/modules/webdav.py
+++ b/cme/modules/webdav.py
@@ -1,0 +1,47 @@
+from cme.protocols.smb.remotefile import RemoteFile
+from impacket import nt_errors
+from impacket.smb3structs import FILE_READ_DATA
+from impacket.smbconnection import SessionError
+
+class CMEModule:
+    '''
+    Enumerate whether the WebClient service is running on the target host by looking for the
+    DAV RPC Service pipe. This technique was first suggested by Lee Christensen (@tifkin_)
+
+    Module by Tobias Neitzel (@qtc_de)
+    '''
+    name = 'webdav'
+    description = 'Checks whether the WebClient service is running on the target host'
+    supported_protocols = ['smb']
+    opsec_safe= True
+    multiple_hosts = True
+
+    def options(self, context, module_options):
+        '''
+        MSG     Info message to use when a host is vulnerable. '{}' is replaced by the target.
+        '''
+        self.output = 'WebClient Service enabled on: {}'
+
+        if 'MSG' in module_options:
+            self.output = module_options['MSG']
+
+    def on_login(self, context, connection):
+        '''
+        Check whether the 'DAV RPC Service' pipe exists within the 'IPC$' share. This indicates
+        that the WebClient service is running on the target host.
+        '''
+        try:
+            remote_file = RemoteFile(connection.conn, 'DAV RPC Service', 'IPC$', access=FILE_READ_DATA)
+
+            remote_file.open()
+            remote_file.close()
+
+            context.log.highlight(self.output.format(connection.conn.getRemoteHost()))
+
+        except SessionError as e:
+            
+            if e.getErrorCode() == nt_errors.STATUS_OBJECT_NAME_NOT_FOUND:
+                pass
+
+            else:
+                raise e

--- a/cme/modules/webdav.py
+++ b/cme/modules/webdav.py
@@ -5,20 +5,20 @@ from impacket.smbconnection import SessionError
 
 class CMEModule:
     '''
-    Enumerate whether the WebClient service is running on the target host by looking for the
+    Enumerate whether the WebClient service is running on the target by looking for the
     DAV RPC Service pipe. This technique was first suggested by Lee Christensen (@tifkin_)
 
     Module by Tobias Neitzel (@qtc_de)
     '''
     name = 'webdav'
-    description = 'Checks whether the WebClient service is running on the target host'
+    description = 'Checks whether the WebClient service is running on the target'
     supported_protocols = ['smb']
     opsec_safe= True
     multiple_hosts = True
 
     def options(self, context, module_options):
         '''
-        MSG     Info message to use when a host is vulnerable. '{}' is replaced by the target.
+        MSG     Info message when the WebClient service is running. '{}' is replaced by the target.
         '''
         self.output = 'WebClient Service enabled on: {}'
 
@@ -28,7 +28,7 @@ class CMEModule:
     def on_login(self, context, connection):
         '''
         Check whether the 'DAV RPC Service' pipe exists within the 'IPC$' share. This indicates
-        that the WebClient service is running on the target host.
+        that the WebClient service is running on the target.
         '''
         try:
             remote_file = RemoteFile(connection.conn, 'DAV RPC Service', 'IPC$', access=FILE_READ_DATA)


### PR DESCRIPTION
Hi there :wave:

this PR adds the webdav module to cme. This module can be used to enumerate whether a target has the *WebClient* service running. Below you find some example output:

```console
$ crackmapexec smb hosts.txt -u user -p password -M webdav
[...]
SMB         10.10.10.11  445    WINSRV0011       [+] local.lab\user:password 
WEBDAV      10.10.10.11  445    WINSRV0011       WebClient Service enabled on: 10.10.10.11
SMB         10.10.10.12  445    WINSRV0012       [+] local.lab\user:password 
SMB         10.10.10.13  445    WINSRV0013       [+] local.lab\user:password 
SMB         10.10.10.14  445    WINSRV0014       [+] local.lab\user:password 
WEBDAV      10.10.10.14  445    WINSRV0014       WebClient Service enabled on: 10.10.10.14
SMB         10.10.10.15  445    WINSRV0015       [+] local.lab\user:password 
WEBDAV      10.10.10.15  445    WINSRV0015       WebClient Service enabled on: 10.10.10.15
SMB         10.10.10.16  445    WINSRV0016       [+] local.lab\user:password 
```

The module is based on a technique that was mentioned by @leechristensen [on twitter](https://twitter.com/tifkin_/status/1419806476353298442). It checks for the ``DAV RPC Service`` pipe within the ``IPC$`` share. If it exists, the *WebClient* service should be running.
