### PR TITLE
Add adcs module

### DIFF
--- a/cme/modules/adcs.py
+++ b/cme/modules/adcs.py
@@ -1,0 +1,82 @@
+import re
+
+from impacket.ldap import ldap, ldapasn1
+from impacket.ldap.ldap import LDAPSearchError
+
+class CMEModule:
+    '''
+    Find PKI Enrollment Services in Active Directory.
+
+    Module by Tobias Neitzel (@qtc_de)
+    '''
+    name = 'adcs'
+    description = 'Find PKI Enrollment Services in Active Directory'
+    supported_protocols = ['ldap']
+    opsec_safe= True
+    multiple_hosts = True
+
+    def options(self, context, module_options):
+        '''
+        The module does not support any module specific options. Instead, just configure
+        some attributes that are required throughout the script.
+        '''
+        self.context = context
+        self.regex = re.compile('(https?://.+)')
+
+    def on_login(self, context, connection):
+        '''
+        On a successful LDAP login we perform a search for all PKI Enrollment Services.
+        '''
+        search_filter = '(objectClass=pKIEnrollmentService)'
+
+        context.log.debug("Starting LDAP search with search filter '{}'".format(search_filter))
+
+        try:
+            sc = ldap.SimplePagedResultsControl()
+            resp = connection.ldapConnection.search(searchFilter=search_filter,
+                                        attributes=['dNSHostName', 'msPKI-Enrollment-Servers'],
+                                        sizeLimit=0, searchControls=[sc],
+                                        perRecordCallback=self.process_record,
+                                        searchBase='CN=Configuration,' + connection.ldapConnection._baseDN)
+
+        except LDAPSearchError as e:
+            context.log.error('Obtained unexpected exception: {}'.format(str(e)))
+
+    def process_record(self, item):
+        '''
+        Function that is called to process the items obtain by the LDAP search.
+        '''
+        if not isinstance(item, ldapasn1.SearchResultEntry):
+            return
+
+        urls = []
+        host_name = None
+
+        try:
+
+            for attribute in item['attributes']:
+
+                if str(attribute['type']) == 'dNSHostName':
+                    host_name = attribute['vals'][0].asOctets().decode('utf-8')
+
+                elif str(attribute['type']) == 'msPKI-Enrollment-Servers':
+
+                    values = attribute['vals']
+
+                    for value in values:
+
+                        value = value.asOctets().decode('utf-8')
+                        match = self.regex.search(value)
+
+                        if match:
+                            urls.append(match.group(1))
+
+        except Exception as e:
+            entry = host_name or 'item'
+            self.context.log.error("Skipping {}, cannot process LDAP entry due to error: '{}'".format(entry, str(e)))
+
+        if host_name:
+            self.context.log.highlight('Found PKI Enrollment Server: {}'.format(host_name))
+
+        for url in urls:
+            self.context.log.highlight('Found PKI Enrollment WebService: {}'.format(url))


### PR DESCRIPTION
Hi there :wave:

this PR adds the *adcs* module that allows to enumerate Active Directory for PKI Enrollment Services. Can be quite useful, especially in the current situation with *PetitPotam* :)

I had only one target to test against. Not sure whether it works 100% reliably, but for my test system everything was fine:

```console
$ crackmapexec ldap local.lab -u user -p password -M adcs
LDAP        10.10.10.100  389    LABDC100    [*] Windows Server ...
LDAP        10.10.10.100  389    LABDC100    [+] local.lab\user:password
ADCS                                         Found PKI Enrollment Server: CA01.local.lab
ADCS                                         Found PKI Enrollment Server: CA02.local.lab
ADCS                                         Found PKI Enrollment WebService: https://enroll01.local.lab/certsrv
ADCS                                         Found PKI Enrollment WebService: https://enroll02.local.lab/certsrv
```