### PR TITLE
Add ldap-signing module

### DIFF
--- a/cme/modules/ldap-signing.py
+++ b/cme/modules/ldap-signing.py
@@ -1,0 +1,46 @@
+from impacket.ldap import ldap
+
+class CMEModule:
+    '''
+    Checks whether LDAP signing is required.
+
+    Module by Tobias Neitzel (@qtc_de)
+    '''
+    name = 'ldap-signing'
+    description = 'Check whether LDAP signing is required'
+    supported_protocols = ['ldap']
+    opsec_safe= True
+    multiple_hosts = True 
+
+    def options(self, context, module_options):
+        '''
+        No options available.
+        '''
+        pass
+
+    def on_login(self, context, connection):
+        '''
+        Perform a second logon attempt without LDAP signing.
+        '''
+        domain = connection.domain
+        username = connection.username
+        password = connection.password
+        ldap_host = connection.conn.getRemoteHost()
+
+        try:
+            connection = ldap.LDAPConnection('ldap://{}'.format(ldap_host))
+            connection.login(username, password, domain, '', '')
+            context.log.highlight('LDAP signing is NOT enforced on {}'.format(ldap_host)) 
+
+        except ldap.LDAPSessionError as e:
+
+            error_msg = str(e)
+
+            if 'strongerAuthRequired' in error_msg:
+                context.log.info('LDAP signing is enforced on {}'.format(ldap_host)) 
+
+            else:
+                context.log.error("Unexpected LDAP error: '{}'".format(error_msg))
+
+        except Exception as e:
+            context.log.error("Unexpected LDAP error: '{}'".format(str(e)))


### PR DESCRIPTION
Hi there :wave:

this PR adds the *ldap-signing* module. A simple module to check whether LDAP signing is enforced by the server.

```console
$ crackmapexec ldap local.lab -u user -p password -M ldap-signing 
LDAP        10.10.10.100  389    LABDC100    [*] Windows Server 2016 ...
LDAP        10.10.10.100  389    LABDC100    [+] local.lab\user:password
LDAP-SIG... 10.10.10.100  389    LABDC100    LDAP signing is NOT enforced on 10.10.10.100
```

However, the overall situation is not ideal. The module uses a secondary *LDAP* logon, that is actually unnecessary. During the login, *cme* actually enumerates *LDAP* signing implicitly. If I'm not mistaken you also perform a login attempt without signing and switch to *LDAPS* if signing is required on the *LDAP* port.

I think it is generally confusing that the *ldap* module of *cme* shows the status of *SMB Signing* instead of *LDAP Signing* within the target information. Wouldn't it make more sense to display the *LDAP Signing* status over there? Theoretically you can use the currently implicit *LDAP Signing* enumeration and display this information instead. However, this would require some significant changes onto the *cme* codebase and I'm not that familiar with your code to implement the changes myself. But this could be a nice feature for future releases. Up to this point, this module can serve a workaround :) 
