### PR TITLE
Add ADCS module option to enumerate templates

### DIFF
--- a/cme/modules/adcs.py
+++ b/cme/modules/adcs.py
@@ -5,46 +5,61 @@ from impacket.ldap.ldap import LDAPSearchError
 
 class CMEModule:
     '''
-    Find PKI Enrollment Services in Active Directory.
+    Find PKI Enrollment Services in Active Directory and Certificate Templates Names.
 
-    Module by Tobias Neitzel (@qtc_de)
+    Module by Tobias Neitzel (@qtc_de) and Sam Freeside (@snovvcrash)
     '''
     name = 'adcs'
-    description = 'Find PKI Enrollment Services in Active Directory'
+    description = 'Find PKI Enrollment Services in Active Directory and Certificate Templates Names'
     supported_protocols = ['ldap']
     opsec_safe= True
     multiple_hosts = True
 
     def options(self, context, module_options):
         '''
-        The module does not support any module specific options. Instead, just configure
-        some attributes that are required throughout the script.
+        SERVER             PKI Enrollment Server to enumerate templates for. Default is None.
         '''
         self.context = context
         self.regex = re.compile('(https?://.+)')
 
+        self.server = None
+        if module_options and 'SERVER' in module_options:
+            self.server = module_options['SERVER']
+            self.context.log.highlight('Using PKI Enrollment Server: {}'.format(self.server))
+
     def on_login(self, context, connection):
         '''
-        On a successful LDAP login we perform a search for all PKI Enrollment Services.
+        On a successful LDAP login we perform a search for all PKI Enrollment Server or Certificate Templates Names.
         '''
-        search_filter = '(objectClass=pKIEnrollmentService)'
+        if self.server is None:
+            search_filter = '(objectClass=pKIEnrollmentService)'
+        else:
+            search_filter = '(distinguishedName=CN={},CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration,'.format(self.server)
 
         context.log.debug("Starting LDAP search with search filter '{}'".format(search_filter))
 
         try:
             sc = ldap.SimplePagedResultsControl()
-            resp = connection.ldapConnection.search(searchFilter=search_filter,
-                                        attributes=['dNSHostName', 'msPKI-Enrollment-Servers'],
-                                        sizeLimit=0, searchControls=[sc],
-                                        perRecordCallback=self.process_record,
-                                        searchBase='CN=Configuration,' + connection.ldapConnection._baseDN)
+
+            if self.server is None:
+                resp = connection.ldapConnection.search(searchFilter=search_filter,
+                                            attributes=['dNSHostName', 'msPKI-Enrollment-Servers'],
+                                            sizeLimit=0, searchControls=[sc],
+                                            perRecordCallback=self.process_servers,
+                                            searchBase='CN=Configuration,' + connection.ldapConnection._baseDN)
+            else:
+                resp = connection.ldapConnection.search(searchFilter=search_filter + connection.ldapConnection._baseDN + ')',
+                                            attributes=['certificateTemplates'],
+                                            sizeLimit=0, searchControls=[sc],
+                                            perRecordCallback=self.process_templates,
+                                            searchBase='CN=Configuration,' + connection.ldapConnection._baseDN)
 
         except LDAPSearchError as e:
             context.log.error('Obtained unexpected exception: {}'.format(str(e)))
 
-    def process_record(self, item):
+    def process_servers(self, item):
         '''
-        Function that is called to process the items obtain by the LDAP search.
+        Function that is called to process the items obtain by the LDAP search when listing PKI Enrollment Servers.
         '''
         if not isinstance(item, ldapasn1.SearchResultEntry):
             return
@@ -80,3 +95,30 @@ class CMEModule:
 
         for url in urls:
             self.context.log.highlight('Found PKI Enrollment WebService: {}'.format(url))
+
+    def process_templates(self, item):
+        '''
+        Function that is called to process the items obtain by the LDAP search when listing Certificate Templates Names for a specific PKI Enrollment Server.
+        '''
+        if not isinstance(item, ldapasn1.SearchResultEntry):
+            return
+
+        templates = []
+        template_name = None
+
+        try:
+
+            for attribute in item['attributes']:
+
+                if str(attribute['type']) == 'certificateTemplates':
+                    for val in attribute['vals']:
+                        template_name = val.asOctets().decode('utf-8')
+                        templates.append(template_name)
+
+        except Exception as e:
+            entry = template_name or 'item'
+            self.context.log.error("Skipping {}, cannot process LDAP entry due to error: '{}'".format(entry, str(e)))
+
+        if templates:
+            for t in templates:
+                self.context.log.highlight('Found Certificate Template: {}'.format(t))

--- a/cme/modules/adcs.py
+++ b/cme/modules/adcs.py
@@ -25,7 +25,6 @@ class CMEModule:
         self.server = None
         if module_options and 'SERVER' in module_options:
             self.server = module_options['SERVER']
-            self.context.log.highlight('Using PKI Enrollment Server: {}'.format(self.server))
 
     def on_login(self, context, connection):
         '''
@@ -35,6 +34,7 @@ class CMEModule:
             search_filter = '(objectClass=pKIEnrollmentService)'
         else:
             search_filter = '(distinguishedName=CN={},CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration,'.format(self.server)
+            self.context.log.highlight('Using PKI Enrollment Server: {}'.format(self.server))
 
         context.log.debug("Starting LDAP search with search filter '{}'".format(search_filter))
 


### PR DESCRIPTION
Hey there!

In this PR I'd like to bring this `SERVER` option for the ADCS module. When specified, it will return a list of discovered certificate templates names for a specific server.

![templates](https://user-images.githubusercontent.com/23141800/139557006-2a8baa5f-da86-44c9-af95-7f521738ade0.png)

