### PR TITLE
Fix winrm login failed

### DIFF
--- a/cme/protocols/winrm.py
+++ b/cme/protocols/winrm.py
@@ -135,7 +135,7 @@ class winrm(connection):
             log.addFilter(SuppressFilter())
             self.conn = Client(self.host,
                                         auth='ntlm',
-                                        username=username,
+                                        username=u'{}\\{}'.format(domain, username),
                                         password=password,
                                         ssl=False)
 
@@ -182,7 +182,7 @@ class winrm(connection):
             if nthash: self.nthash = nthash
             self.conn = Client(self.host,
                                         auth='ntlm',
-                                        username=username,
+                                        username=u'{}\\{}'.format(domain, username),
                                         password=ntlm_hash,
                                         ssl=False)
 


### PR DESCRIPTION
When you want to login to WinRM with a domain user (plaintext password or NT hash), CME always fails

```bash
$ cme winrm 10.0.1.220 -d test.lab -u administrator -p dlive@test.lab 
WINRM       10.0.1.220      5985   10.0.1.220       [*] http://10.0.1.220:5985/wsman
WINRM       10.0.1.220      5985   10.0.1.220       [-] test.lab\administrator:dlive@test.lab 
```

This PR has fixed this issue.