### PR TITLE
fix filename for IPv6 on win32

### DIFF
--- a/cme/protocols/ldap.py
+++ b/cme/protocols/ldap.py
@@ -124,6 +124,7 @@ class ldap(connection):
         self.os_arch   = self.get_os_arch()
 
         self.output_filename = os.path.expanduser('~/.cme/logs/{}_{}_{}'.format(self.hostname, self.host, datetime.now().strftime("%Y-%m-%d_%H%M%S")))
+        self.output_filename = self.output_filename.replace(":", "-")
 
         if not self.domain:
             self.domain = self.hostname

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -240,6 +240,7 @@ class smb(connection):
         self.os_arch   = self.get_os_arch()
 
         self.output_filename = os.path.expanduser('~/.cme/logs/{}_{}_{}'.format(self.hostname, self.host, datetime.now().strftime("%Y-%m-%d_%H%M%S")))
+        self.output_filename = self.output_filename.replace(":", "-")
 
         if not self.domain:
             self.domain = self.hostname


### PR DESCRIPTION
On MS Windows, NTFS filesystem the  `:` is a special characters used for Alternate Data Streams. 

If the host has enabled IPv6 support then `gethost_addrinfo`
``` python
def gethost_addrinfo(hostname):
    try:
        for res in socket.getaddrinfo(hostname, None, socket.AF_INET6,
                socket.SOCK_DGRAM, socket.IPPROTO_IP, socket.AI_CANONNAME):
            af, socktype, proto, canonname, sa = res
    except socket.gaierror:
        for res in socket.getaddrinfo(hostname, None, socket.AF_INET,
                socket.SOCK_DGRAM, socket.IPPROTO_IP, socket.AI_CANONNAME):
            af, socktype, proto, canonname, sa = res
    if canonname == '':
        return sa[0]
    return canonname
```
will convert IPv4 address or hostname from the hosts file into an IPv6 address.

The `output_filename` in ldap.py and smb.py is formatted with IPv6 address in the name and therefore we need to replace any occurrence of `:` in the file name with some harmless character. I've arbitrary chosen the `-`   