### PR TITLE
Bug fix

### DIFF
--- a/cme/modules/lsassy_dump.py
+++ b/cme/modules/lsassy_dump.py
@@ -76,6 +76,7 @@ class CMEModule:
         self.process_credentials(context, connection, credentials_output)
 
     def process_credentials(self, context, connection, credentials):
+        domain=None
         if len(credentials) == 0:
             context.log.info("No credentials found")
         credz_bh = []


### PR DESCRIPTION
Sometimes the "domain" variable was not assigned before trying to call the "add_user_bh" function. 
This leads to an annoying crash 

````
File "XXXX/CrackMapExec/cme/modules/lsassy_dump.py", line 89, in process_credentials
    add_user_bh(credz_bh, domain, context.log, connection.config)
UnboundLocalError: local variable 'domain' referenced before assignment
````

This quick and dirty commit fix it !