### PR TITLE
Fix mssql check_if_admin function

### DIFF
--- a/cme/protocols/mssql.py
+++ b/cme/protocols/mssql.py
@@ -134,7 +134,7 @@ class mssql(connection):
 
         return True
 
-    def check_if_admin(self, auth):
+    def check_if_admin(self):
         try:
             self.conn.sql_query("SELECT IS_SRVROLEMEMBER('sysadmin')")
             self.conn.printRows()
@@ -167,7 +167,7 @@ class mssql(connection):
             self.password = password
             self.username = username
             self.domain = domain
-            self.check_if_admin(self.args.local_auth)
+            self.check_if_admin()
             self.db.add_credential('plaintext', domain, username, password)
 
             if self.admin_privs:


### PR DESCRIPTION
The check_if_admin function from `mssql.py` takes an additional `auth` parameter, that is actually not used. Other parts of the code are calling the function without the parameter, which leads to an error when enumerating mssql endpoints. By simply removing the parameter and fixing the locations that use it, the issue gets resolved.

The actual bug is currently sitting at line 216. This line calls the `check_if_admin` function with no parameters, despite the current version requires one.