### PR TITLE
Fix missing BloodHound section bug

### DIFF
--- a/cme/helpers/bloodhound.py
+++ b/cme/helpers/bloodhound.py
@@ -1,46 +1,63 @@
 def add_user_bh(user, domain, logger, config):
-    users_owned = []
+
+    if not config.has_option('BloodHound', 'bh_enabled') or config.get('BloodHound', 'bh_enabled') == "False":
+        return
+
+    from neo4j.exceptions import AuthError, ServiceUnavailable
+
+    try:
+        from neo4j.v1 import GraphDatabase
+    except:
+        from neo4j import GraphDatabase
+
     if isinstance(user, str):
-        users_owned.append({'username': user.upper(), 'domain': domain.upper()})
+        users_owned = [{'username': user.upper(), 'domain': domain.upper()}]
     else:
         users_owned = user
-    if config.get('BloodHound', 'bh_enabled') != "False":
-        try:
-            from neo4j.v1 import GraphDatabase
-        except:
-            from neo4j import GraphDatabase
-        from neo4j.exceptions import AuthError, ServiceUnavailable
-        uri = "bolt://{}:{}".format(config.get('BloodHound', 'bh_uri'), config.get('BloodHound', 'bh_port'))
 
-        driver = GraphDatabase.driver(uri, auth=(config.get('BloodHound', 'bh_user'), config.get('BloodHound', 'bh_pass')), encrypted=False)
-        try:
-            with driver.session() as session:
-                with session.begin_transaction() as tx:
-                    for info in users_owned:
-                        if info['username'][-1] == '$':
-                            user_owned = info['username'][:-1] + "." + info['domain']
-                            account_type = 'Computer'
-                        else:
-                            user_owned = info['username'] + "@" + info['domain']
-                            account_type = 'User'
+    bh_uri = config.get('Bloodhound', 'bh_uri')
+    bh_port = config.get('Bloodhound', 'bh_port')
+    bh_user = config.get('Bloodhound', 'bh_user')
+    bh_pass = config.get('Bloodhound', 'bh_pass')
 
-                        result = tx.run(
-                            "MATCH (c:{} {{name:\"{}\"}}) RETURN c".format(account_type, user_owned))
+    uri = "bolt://{}:{}".format(bh_uri, bh_port)
+    driver = GraphDatabase.driver(uri, auth=(bh_user, bh_port), encrypted=False)
 
-                        if result.data()[0]['c'].get('owned') in (False, None):
-                            logger.debug("MATCH (c:{} {{name:\"{}\"}}) SET c.owned=True RETURN c.name AS name".format(account_type, user_owned))
-                            result = tx.run(
-                                "MATCH (c:{} {{name:\"{}\"}}) SET c.owned=True RETURN c.name AS name".format(account_type, user_owned))
-                            logger.highlight("Node {} successfully set as owned in BloodHound".format(user_owned))
-        except AuthError as e:
-            logger.error(
-                "Provided Neo4J credentials ({}:{}) are not valid.".format(config.get('Bloodhound', 'bh_user'), config.get('Bloodhound', 'bh_pass')))
-            return
-        except ServiceUnavailable as e:
-            logger.error("Neo4J does not seem to be available on {}.".format(uri))
-            return
-        except Exception as e:
-            logger.error("Unexpected error with Neo4J")
-            logger.error("Error : ".format(str(e)))
-            return
-        driver.close()
+    try:
+        with driver.session() as session:
+            with session.begin_transaction() as tx:
+
+                for info in users_owned:
+
+                    username = info['username']
+                    domain = info['domain']
+
+                    if username[-1] == '$':
+                        user_owned = "{}.{}".format(username[:-1], domain)
+                        account_type = 'Computer'
+
+                    else:
+                        user_owned = "{}@{}".format(username, domain)
+                        account_type = 'User'
+
+                    result = tx.run( "MATCH (c:{} {{name:\"{}\"}}) RETURN c".format(account_type, user_owned))
+
+                    if result.data()[0]['c'].get('owned') in (False, None):
+                        logger.debug("MATCH (c:{} {{name:\"{}\"}}) SET c.owned=True RETURN c.name AS name".format(account_type, user_owned))
+                        result = tx.run( "MATCH (c:{} {{name:\"{}\"}}) SET c.owned=True RETURN c.name AS name".format(account_type, user_owned))
+                        logger.highlight("Node {} successfully set as owned in BloodHound".format(user_owned))
+
+    except AuthError as e:
+        logger.error("Provided Neo4J credentials ({}:{}) are not valid.".format(bh_user, bh_pass))
+        return
+
+    except ServiceUnavailable as e:
+        logger.error("Neo4J does not seem to be available on {}.".format(uri))
+        return
+
+    except Exception as e:
+        logger.error("Unexpected error with Neo4J")
+        logger.error("Error : ".format(str(e)))
+        return
+
+    driver.close()

--- a/cme/helpers/bloodhound.py
+++ b/cme/helpers/bloodhound.py
@@ -21,7 +21,7 @@ def add_user_bh(user, domain, logger, config):
     bh_pass = config.get('Bloodhound', 'bh_pass')
 
     uri = "bolt://{}:{}".format(bh_uri, bh_port)
-    driver = GraphDatabase.driver(uri, auth=(bh_user, bh_port), encrypted=False)
+    driver = GraphDatabase.driver(uri, auth=(bh_user, bh_pass), encrypted=False)
 
     try:
         with driver.session() as session:


### PR DESCRIPTION
When updating from an older cme version to the new one, `bloodhound.py` raising an exception because it attempts to access the `BloodHound` section from the cme config file, which previously did not exist. This commit fixes this issue, by adding a check before performing the action. Additionally, I refactored the code a little bit to make it more readable. A review would be nice to make sure that nothing got broken.

The following listing shows the staktrace that is raised without the fix and an old cme config:

```python3
Traceback (most recent call last):
  File "/usr/bin/crackmapexec", line 8, in <module>
    sys.exit(main())
  File "/usr/lib/python3/dist-packages/cme/crackmapexec.py", line 254, in main
    asyncio.run(
  File "/usr/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/usr/lib/python3/dist-packages/cme/crackmapexec.py", line 102, in start_threadpool
    await asyncio.gather(*jobs)
  File "/usr/lib/python3/dist-packages/cme/crackmapexec.py", line 68, in run_protocol
    await asyncio.wait_for(
  File "/usr/lib/python3.9/asyncio/tasks.py", line 442, in wait_for
    return await fut
  File "/usr/lib/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3/dist-packages/cme/protocols/smb.py", line 126, in __init__
    connection.__init__(self, args, db, host)
  File "/usr/lib/python3/dist-packages/cme/connection.py", line 62, in __init__
    self.proto_flow()
  File "/usr/lib/python3/dist-packages/cme/connection.py", line 98, in proto_flow
    if self.login() or (self.username == '' and self.password == ''):
  File "/usr/lib/python3/dist-packages/cme/connection.py", line 275, in login
    if self.plaintext_login(self.domain, user, password): return True
  File "/usr/lib/python3/dist-packages/cme/protocols/smb.py", line 385, in plaintext_login
    add_user_bh(self.username, self.domain, self.logger, self.config)
  File "/usr/lib/python3/dist-packages/cme/helpers/bloodhound.py", line 7, in add_user_bh
    if config.get('BloodHound', 'bh_enabled') != "False":
  File "/usr/lib/python3.9/configparser.py", line 781, in get
    d = self._unify_values(section, vars)
  File "/usr/lib/python3.9/configparser.py", line 1152, in _unify_values
    raise NoSectionError(section) from None
configparser.NoSectionError: No section: 'BloodHound'
```