### PR TITLE
Add STATUS_NO_SUCH_FILE to success status

### DIFF
--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -51,7 +51,8 @@ smb_error_status = [
     "STATUS_LOGON_TYPE_NOT_GRANTED",
     "STATUS_PASSWORD_EXPIRED",
     "STATUS_PASSWORD_MUST_CHANGE",
-    "STATUS_ACCESS_DENIED"
+    "STATUS_ACCESS_DENIED",
+    "STATUS_NO_SUCH_FILE"
 ]
 
 def requires_smb_server(func):


### PR DESCRIPTION
When starting *impackets* `smbserver.py` and running cme on it, cme does not identify valid credentials correctly:

```console
$ impacket-smbserver share /tmp/share  -username example -password example -smb2support
...

$ crackmapexec smb 127.0.0.1 -u example -p example -d .
...
SMB         127.0.0.1       445    vzXuADiH         [-] .\example:example STATUS_NO_SUCH_FILE
```

Okay... I see... A listing does not outline the point here. Here is a screenshot where you can find the red marker, which indicates wrong credentials:

![image](https://user-images.githubusercontent.com/49147108/156653112-f1b4ef5b-9487-4163-8118-271ba08f7a99.png)

This PR adds `STATUS_NO_SUCH_FILE` to the smb errors that still indicate a valid authentication:

![image](https://user-images.githubusercontent.com/49147108/156653248-f8006d95-3e28-4d7d-b053-de1071d589c6.png)


