### PR TITLE
Fixed instability issues for SMB (no _Connection crash, NetBIOSTimeout crash, UnsupportedFeature-crash)

### DIFF
--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -55,6 +55,12 @@ smb_error_status = [
     "STATUS_NO_SUCH_FILE"
 ]
 
+def get_error_string(exception):
+    if hasattr(exception, 'getErrorString'):
+        exception.getErrorString()
+    else:
+        str(exception)
+
 def requires_smb_server(func):
     def _decorator(self, *args, **kwargs):
         global smb_server
@@ -237,7 +243,11 @@ class smb(connection):
         self.domain    = self.conn.getServerDNSDomainName()
         self.hostname  = self.conn.getServerName()
         self.server_os = self.conn.getServerOS()
-        self.signing   = self.conn.isSigningRequired() if self.smbv1 else self.conn._SMBConnection._Connection['RequireSigning']
+        try:
+            self.signing   = self.conn.isSigningRequired() if self.smbv1 else self.conn._SMBConnection._Connection['RequireSigning']
+        except:
+            pass
+
         self.os_arch   = self.get_os_arch()
 
         self.output_filename = os.path.expanduser('~/.cme/logs/{}_{}_{}'.format(self.hostname, self.host, datetime.now().strftime("%Y-%m-%d_%H%M%S")))
@@ -639,7 +649,7 @@ class smb(connection):
         except (SessionError, UnicodeEncodeError) as e:
             self.logger.error('Error enumerating shares: {}'.format(e))     
         except Exception as e:
-            error = e.getErrorString()
+            error = get_error_string(e)
             self.logger.error('Error enumerating shares: {}'.format(error),
                             color='magenta' if error in smb_error_status else 'red')          
 


### PR DESCRIPTION
The following three crash-behaviors have been removed
- SMB object not having _Connection
- NetBIOSTimeout
- UnsupportedFeature

This has been tested over a very extensive set of IP-ranges (7400 IP:s)
Images of the crashes from before the fixes can be seen as attached files.

![Crash_no_attribute_Connection](https://user-images.githubusercontent.com/302673/161141195-e0550585-7a16-427c-bf12-6d4dcfc34c84.png)

![NetBIOSTimeout](https://user-images.githubusercontent.com/302673/161141178-8f473f2d-7aed-4944-890c-cd4e55123901.png)

![UnsupportedFeature_SMB](https://user-images.githubusercontent.com/302673/161141166-8a1eb03b-b1ae-4bb7-9644-a9288f63a257.png)
 