### PR TITLE
Stop crackmapexec crashing from concurrency-issues (tested with SMB-mode)

### DIFF
--- a/cme/crackmapexec.py
+++ b/cme/crackmapexec.py
@@ -75,6 +75,8 @@ async def run_protocol(loop, protocol_obj, args, db, target, jitter):
     except asyncio.CancelledError:
         logging.debug("Stopping thread")
         thread.cancel()
+    except sqlite3.OperationalError as e:
+        logging.debug("Sqlite error - sqlite3.operationalError - {}".format(str(e)))
 
 async def start_threadpool(protocol_obj, args, db, targets, jitter):
     pool = ThreadPoolExecutor(max_workers=args.threads + 1)


### PR DESCRIPTION
When crackmapexec is used with SMB over a large amount of IP-addresses, and gets to run for an extended period of time - it will eventually run into a lock-contention crash which manifests itself as the following

>   File ".../CrackMapExec/cme/protocols/smb.py", line 259, in enum_host_info
>     self.db.add_computer(self.host, self.hostname, self.domain, self.server_os)
>   File ".../CrackMapExec/cme/protocols/smb/database.py", line 162, in add_computer
>     cur.execute("INSERT INTO computers (ip, hostname, domain, os, dc) VALUES (?,?,?,?,?)", [ip, hostname, domain, os, dc])
> sqlite3.OperationalError: unable to open database file

or this

> 
>   File ".../CrackMapExec/cme/protocols/smb.py", line 259, in enum_host_info
>     self.db.add_computer(self.host, self.hostname, self.domain, self.server_os)
>   File ".../CrackMapExec/cme/protocols/smb/database.py", line 166, in add_computer
>     cur.execute("UPDATE computers SET hostname=?, domain=?, os=? WHERE id=?", [hostname, domain, os, host[0]])
> sqlite3.OperationalError: unable to open database file
> 

The problem can be triggered faster and more frequently when increasing the amount of threads with -t 1000 or similar.
Analysis of the source in smb/database.py suggests that the problem manifests itself on the operations which need to lock the database, such as INSERT and UPDATE - while the SELECT on line 158 will always succeed as it will not lock.

This patch will not stop the crash from happening - but, it does stop the whole crackmapexec-run from stopping due to one thread failing when opening the database.
