### PR TITLE
Add -codec execution option

### DIFF
--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -180,6 +180,11 @@ class smb(connection):
 
         cgroup = smb_parser.add_argument_group("Command Execution", "Options for executing commands")
         cgroup.add_argument('--exec-method', choices={"wmiexec", "mmcexec", "smbexec", "atexec"}, default=None, help="method to execute the command. Ignored if in MSSQL mode (default: wmiexec)")
+        cgroup.add_argument('--codec', default='utf-8', help='Set encoding used (codec) from the target\'s output (default '
+                                                             '"utf-8"). If errors are detected, run chcp.com at the target, '
+                                                             'map the result with '
+                                                             'https://docs.python.org/3/library/codecs.html#standard-encodings and then execute '
+                                                             'again with --codec and the corresponding codec')
         cgroup.add_argument('--force-ps32', action='store_true', help='force the PowerShell command to run in a 32-bit process')
         cgroup.add_argument('--no-output', action='store_true', help='do not retrieve command output')
         cegroup = cgroup.add_mutually_exclusive_group()
@@ -560,7 +565,16 @@ class smb(connection):
 
         if hasattr(self, 'server'): self.server.track_host(self.host)
 
-        output = u'{}'.format(exec_method.execute(payload, get_output).strip())
+        output = exec_method.execute(payload, get_output)
+
+        try:
+            if not isinstance(output, str):
+                output = output.decode(self.args.codec)
+        except UnicodeDecodeError:
+            logging.debug('Decoding error detected, consider running chcp.com at the target, map the result with https://docs.python.org/3/library/codecs.html#standard-encodings')
+            output = output.decode('cp437')
+
+        output = u'{}'.format(output.strip())
 
         if self.args.execute or self.args.ps_execute:
             self.logger.success('Executed command {}'.format('via {}'.format(self.args.exec_method) if self.args.exec_method else ''))

--- a/cme/protocols/smb/atexec.py
+++ b/cme/protocols/smb/atexec.py
@@ -42,13 +42,7 @@ class TSCH_EXEC:
     def execute(self, command, output=False):
         self.__retOutput = output
         self.execute_handler(command)
-        try:
-            if isinstance(self.__outputBuffer, str):
-                return self.__outputBuffer
-            return self.__outputBuffer.decode()
-        except UnicodeDecodeError:
-            logging.debug('Decoding error detected, consider running chcp.com at the target, map the result with https://docs.python.org/3/library/codecs.html#standard-encodings')
-            return self.__outputBuffer.decode('cp437')
+        return self.__outputBuffer
 
     def output_callback(self, data):
         self.__outputBuffer = data

--- a/cme/protocols/smb/mmcexec.py
+++ b/cme/protocols/smb/mmcexec.py
@@ -52,7 +52,7 @@ class MMCEXEC:
         self.__nthash = ''
         self.__share_name = share_name
         self.__output = None
-        self.__outputBuffer = ''
+        self.__outputBuffer = b''
         self.__shell = 'c:\\windows\\system32\\cmd.exe'
         self.__pwd = 'C:\\'
         self.__quit = None
@@ -174,7 +174,7 @@ class MMCEXEC:
         self.get_output_fileless()
 
     def output_callback(self, data):
-        self.__outputBuffer += data.decode("utf-8") 
+        self.__outputBuffer += data
 
     def get_output_fileless(self):
         if not self.__retOutput: return

--- a/cme/protocols/smb/smbexec.py
+++ b/cme/protocols/smb/smbexec.py
@@ -76,13 +76,7 @@ class SMBEXEC:
         else:
             self.execute_remote(command)
         self.finish()
-        try:
-            if isinstance(self.__outputBuffer, str):
-                return self.__outputBuffer
-            return self.__outputBuffer.decode()
-        except UnicodeDecodeError:
-            logging.debug('Decoding error detected, consider running chcp.com at the target, map the result with https://docs.python.org/3/library/codecs.html#standard-encodings')
-            return self.__outputBuffer.decode('cp437')
+        return self.__outputBuffer
         
 
     def output_callback(self, data):

--- a/cme/protocols/smb/wmiexec.py
+++ b/cme/protocols/smb/wmiexec.py
@@ -55,13 +55,7 @@ class WMIEXEC:
         else:
             self.execute_handler(command)
         self.__dcom.disconnect()
-        try:
-            if isinstance(self.__outputBuffer, str):
-                return self.__outputBuffer
-            return self.__outputBuffer.decode()
-        except UnicodeDecodeError:
-            logging.debug('Decoding error detected, consider running chcp.com at the target, map the result with https://docs.python.org/3/library/codecs.html#standard-encodings')
-            return self.__outputBuffer.decode('cp437')
+        return self.__outputBuffer
 
     def cd(self, s):
         self.execute_remote('cd ' + s)


### PR DESCRIPTION
Hi @mpgn!

In this PR I'd like to add `--codec` option to execution methods. I've been always suffering from the inability to specify my own codec for exec output readability (English is not native language for most of my customers), so I had to modify CME source every time I deploy a new Kali instance. So I though if there's a chance to put this in the upstream to make my like a bit easier :sweat_smile:

![demo](https://user-images.githubusercontent.com/23141800/165318506-c682c91e-2bab-4f64-885c-ced63c54e5af.png)
