### PR TITLE
Nix Support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,92 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1649676176,
+        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1649676176,
+        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1651248272,
+        "narHash": "sha256-rMqS47Q53lZQDDwrFgLnWI5E+GaalVt4uJfIciv140U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8758d58df0798db2b29484739ca7303220a739d3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1651248272,
+        "narHash": "sha256-rMqS47Q53lZQDDwrFgLnWI5E+GaalVt4uJfIciv140U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8758d58df0798db2b29484739ca7303220a739d3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1651165059,
+        "narHash": "sha256-/psJg8NsEa00bVVsXiRUM8yL/qfu05zPZ+jJzm7hRTo=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "ece2a41612347a4fe537d8c0a25fe5d8254835bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "poetry2nix": "poetry2nix"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "Application packaged using poetry2nix";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+  inputs.poetry2nix.url = "github:nix-community/poetry2nix";
+
+  outputs = { self, nixpkgs, flake-utils, poetry2nix }:
+    {
+      # Nixpkgs overlay providing the application
+      overlay = nixpkgs.lib.composeManyExtensions [
+        poetry2nix.overlay
+        (final: prev: {
+          # The application
+          myapp = prev.poetry2nix.mkPoetryApplication {
+            projectDir = ./.;
+          };
+        })
+      ];
+    } // (flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ self.overlay ];
+        };
+      in
+      {
+        apps = {
+          myapp = pkgs.myapp;
+        };
+
+        defaultApp = pkgs.myapp;
+      }));
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
         poetry2nix.overlay
         (final: prev: {
           # The application
-          CME = prev.poetry2nix.mkPoetryApplication {
+          CrackMapExec = prev.poetry2nix.mkPoetryApplication {
             projectDir = ./.;
           };
         })
@@ -26,11 +26,11 @@
       in
       {
         apps = {
-          CME = pkgs.CME;
+          CrackMapExec = pkgs.CrackMapExec;
         };
 
-        defaultApp = pkgs.CME;
+        defaultApp = pkgs.CrackMapExec;
 
-        packages = { CME = pkgs.CME; };
+        packages = { CrackMapExec = pkgs.CrackMapExec; };
       }));
 }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
         poetry2nix.overlay
         (final: prev: {
           # The application
-          myapp = prev.poetry2nix.mkPoetryApplication {
+          CME = prev.poetry2nix.mkPoetryApplication {
             projectDir = ./.;
           };
         })
@@ -26,9 +26,11 @@
       in
       {
         apps = {
-          myapp = pkgs.myapp;
+          CME = pkgs.CME;
         };
 
-        defaultApp = pkgs.myapp;
+        defaultApp = pkgs.CME;
+
+        packages = { ... };
       }));
 }

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,6 @@
 
         defaultApp = pkgs.CME;
 
-        packages = { ... };
+        packages = { CME = pkgs.CME; };
       }));
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  myAppEnv = pkgs.poetry2nix.mkPoetryEnv {
+    projectDir = ./.;
+    editablePackageSources = {
+      my-app = ./src;
+    };
+  };
+in myAppEnv.env


### PR DESCRIPTION
Hi, I am not sure if this is a feature you where looking to implament, but I put in the work, and I thought I would put it here as a way of contribution to the project. 

## Things Done: 

- [X] Add nix flake support.
- [X] Add nix-shell support.

## How to use: 

- Run `nix shell github:byt3bl33d3r/CrackMapExec` and you will have a shell with CME in it. 
- From within the repo run `nix-shell` and you will have a shell with CME in it. 

## Reason for change: 

Python applications are poorly supported on NixOS, and I was working with Poetry2Nix to run CME on my machine. At that point, I had put in about half the work needed for this to work, and I decided to proceed forward and open a PR. Thanks for looking either way! 