### PR TITLE
Use beautifulsoup4 instead of bs4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ cmedb = 'cme.cmedb:main'
 [tool.poetry.dependencies]
 python = "^3.7.0"
 requests = ">=2.27.1"
-bs4 = "^0.0.1"
+beautifulsoup4 = ">=4.11,<5"
 lsassy = ">=3.1.1"
 termcolor = "^1.1.0"
 msgpack = "^1.0.0"


### PR DESCRIPTION
`bs4` is dummy package for `beautifulsoup4`. Distributions usually don't ship `bs4` but `beautifulsoup4` and this requires them to patch as often the requirements are collected from the `pyproject.toml` files.