### PR TITLE
Add nanodump results to cmedb

### DIFF
--- a/cme/modules/nanodump.py
+++ b/cme/modules/nanodump.py
@@ -148,10 +148,18 @@ class CMEModule:
                                 if NThash is not None:
                                     NThash = NThash.hex()
                                 if username and (password or NThash) and "$" not in username:
-                                    print_pass = password if password else NThash
-                                    context.log.highlight(domain + "\\" + username + ":" + print_pass)
+                                    if password:
+                                        credtype = "password"
+                                        credential = password
+                                    else:
+                                        credtype = "hash"
+                                        credential = NThash
+                                    context.log.highlight(domain + "\\" + username + ":" + credential)
+                                    domain = connection.domain
+                                    credtype = "password" if password else "hash"
+                                    hostid = context.db.get_computers(connection.host)[0][0]
+                                    context.db.add_credential(credtype, domain, username, credential, pillaged_from=hostid)
                                     if "." not in domain and domain.upper() in connection.domain.upper():
-                                        domain = connection.domain
                                         credz_bh.append({'username': username.upper(), 'domain': domain.upper()})
                     if len(credz_bh) > 0:
                         add_user_bh(credz_bh, None, context.log, connection.config)

--- a/cme/modules/nanodump.py
+++ b/cme/modules/nanodump.py
@@ -155,11 +155,11 @@ class CMEModule:
                                         credtype = "hash"
                                         credential = NThash
                                     context.log.highlight(domain + "\\" + username + ":" + credential)
-                                    domain = connection.domain
                                     credtype = "password" if password else "hash"
                                     hostid = context.db.get_computers(connection.host)[0][0]
-                                    context.db.add_credential(credtype, domain, username, credential, pillaged_from=hostid)
+                                    context.db.add_credential(credtype, connection.domain, username, credential, pillaged_from=hostid)
                                     if "." not in domain and domain.upper() in connection.domain.upper():
+                                        domain = connection.domain
                                         credz_bh.append({'username': username.upper(), 'domain': domain.upper()})
                     if len(credz_bh) > 0:
                         add_user_bh(credz_bh, None, context.log, connection.config)

--- a/cme/modules/nanodump.py
+++ b/cme/modules/nanodump.py
@@ -155,7 +155,6 @@ class CMEModule:
                                         credtype = "hash"
                                         credential = NThash
                                     context.log.highlight(domain + "\\" + username + ":" + credential)
-                                    credtype = "password" if password else "hash"
                                     hostid = context.db.get_computers(connection.host)[0][0]
                                     context.db.add_credential(credtype, connection.domain, username, credential, pillaged_from=hostid)
                                     if "." not in domain and domain.upper() in connection.domain.upper():


### PR DESCRIPTION
Added a few lines of code to add passwords and hashes to cmedb.
This might come in handy to provide an overview of credentials after running the module against many targets.