### PR TITLE
fix OUTPUT option description in spider_plus

### DIFF
--- a/cme/modules/spider_plus.py
+++ b/cme/modules/spider_plus.py
@@ -303,7 +303,7 @@ class CMEModule:
             EXCLUDE_EXTS        Extension file to exclude (Default: ico,lnk)
             EXCLUDE_DIR         Directory to exclude (Default: print$)
             MAX_FILE_SIZE       Max file size allowed to dump (Default: 51200)
-            OUTPUT_FOLDER       Path of the remote folder where the dump will occur (Default: /tmp/cme_spider_plus)
+            OUTPUT              Path of the remote folder where the dump will occur (Default: /tmp/cme_spider_plus)
         """
 
         self.read_only = module_options.get('READ_ONLY', True)


### PR DESCRIPTION
There's an issue with the spider_plus module description incorrectly stating the option name for the output path. 

The current description for the spider_plus module shows:
`        OUTPUT_FOLDER       Path of the remote folder where the dump will occur (Default: /tmp/cme_spider_plus)`
[See code here](https://github.com/Porchetta-Industries/CrackMapExec/blob/fd1336b1afb8a8fa6514c786e6680e57d94f9231/cme/modules/spider_plus.py#L306)

However, the code looks only for `OUTPUT`:
`        context.log.info('    OUTPUT: {output}'.format(output=self.output_folder))`
[See code here](https://github.com/Porchetta-Industries/CrackMapExec/blob/fd1336b1afb8a8fa6514c786e6680e57d94f9231/cme/modules/spider_plus.py#L321)

This PR fixes the module description to correctly show `OUTPUT` instead of `OUTPUT_FOLDER`.